### PR TITLE
feat(config): add YAML config file for centralized defaults

### DIFF
--- a/core/cli/config.py
+++ b/core/cli/config.py
@@ -1,18 +1,137 @@
 """Configuration handling for HADES CLI.
 
-Resolves environment variables and provides typed configuration access.
+Loads configuration from YAML, environment variables, and CLI arguments.
+Override priority (highest wins):
+  1. CLI arguments
+  2. Environment variables
+  3. YAML config file
 """
 
 from __future__ import annotations
 
+import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Default config file location (relative to this file)
+DEFAULT_CONFIG_PATH = Path(__file__).parent.parent / "config" / "hades.yaml"
+
+
+def _load_yaml_config(config_path: Path | None = None) -> dict[str, Any]:
+    """Load configuration from YAML file.
+
+    Args:
+        config_path: Path to config file (uses DEFAULT_CONFIG_PATH if not specified)
+
+    Returns:
+        Configuration dictionary, empty dict if file not found or empty
+
+    Raises:
+        TypeError: If YAML file exists but contains non-mapping content
+            (e.g., a list or scalar instead of a dict)
+    """
+    path = config_path or DEFAULT_CONFIG_PATH
+    if path.exists():
+        with open(path) as f:
+            loaded = yaml.safe_load(f)
+        # Handle empty file
+        if loaded is None:
+            return {}
+        # Validate that loaded content is a mapping (dict)
+        if not isinstance(loaded, dict):
+            raise TypeError(
+                f"Config file {path} must contain a YAML mapping (dict) at the top level, "
+                f"got {type(loaded).__name__}. Expected format: 'key: value' pairs."
+            )
+        return loaded
+    logger.debug(f"Config file not found: {path}")
+    return {}
+
+
+def _get_nested(config: dict, *keys: str, default: Any = None) -> Any:
+    """Get a nested value from a dict using dot-notation keys.
+
+    Args:
+        config: Configuration dictionary
+        *keys: Sequence of keys to traverse
+        default: Default value if key not found
+
+    Returns:
+        Value at the nested key path, or default
+    """
+    value = config
+    for key in keys:
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            return default
+        if value is None:
+            return default
+    return value
+
+
+@dataclass
+class EmbeddingConfig:
+    """Embedding service configuration."""
+
+    # Service settings
+    service_socket: str = "/run/hades/embedder.sock"
+    fallback_to_local: bool = True
+    timeout_ms: int = 30000
+
+    # Model settings
+    model_name: str = "jinaai/jina-embeddings-v4"
+    dimension: int = 2048
+    max_tokens: int = 32768
+    use_fp16: bool = True
+    normalize: bool = True
+
+    # Batch settings
+    batch_size: int = 48
+    batch_size_small: int = 8
+
+    # Chunking settings
+    chunk_size_tokens: int = 500
+    chunk_overlap_tokens: int = 200
+
+
+@dataclass
+class SearchConfig:
+    """Search configuration."""
+
+    limit: int = 10
+    max_limit: int = 100
+    hybrid_vector_weight: float = 0.7
+    hybrid_keyword_weight: float = 0.3
+
+
+@dataclass
+class RocchioConfig:
+    """Rocchio relevance feedback configuration."""
+
+    alpha: float = 1.0
+    beta: float = 0.75
+    gamma: float = 0.15
+
+
+@dataclass
+class SyncConfig:
+    """Sync configuration."""
+
+    default_lookback_days: int = 7
+    batch_size: int = 8
+    max_results: int = 1000
 
 
 @dataclass
 class CLIConfig:
-    """CLI configuration resolved from environment variables."""
+    """CLI configuration resolved from YAML + environment variables."""
 
     # ArangoDB settings
     arango_password: str
@@ -23,16 +142,26 @@ class CLIConfig:
     arango_rw_socket: str | None = None
 
     # ArXiv settings
-    pdf_base_path: Path = Path("/bulk-store/arxiv-data/pdf")
-    latex_base_path: Path = Path("/bulk-store/arxiv-data/src")
+    pdf_base_path: Path = field(default_factory=lambda: Path("/bulk-store/arxiv-data/pdf"))
+    latex_base_path: Path = field(default_factory=lambda: Path("/bulk-store/arxiv-data/src"))
 
     # Processing settings
     use_gpu: bool = True
     device: str = "cuda"
 
+    # Nested configs
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    search: SearchConfig = field(default_factory=SearchConfig)
+    rocchio: RocchioConfig = field(default_factory=RocchioConfig)
+    sync: SyncConfig = field(default_factory=SyncConfig)
 
-def get_config() -> CLIConfig:
-    """Load configuration from environment variables.
+
+def get_config(config_path: Path | None = None) -> CLIConfig:
+    """Load configuration from YAML and environment variables.
+
+    Configuration sources (override priority, highest wins):
+        1. Environment variables (ARANGO_*, HADES_*)
+        2. YAML config file (core/config/hades.yaml)
 
     Required environment variables:
         ARANGO_PASSWORD: Password for ArangoDB authentication
@@ -41,11 +170,16 @@ def get_config() -> CLIConfig:
         ARANGO_HOST: ArangoDB host (default: localhost)
         ARANGO_PORT: ArangoDB port (default: 8529)
         HADES_DATABASE: Database name (default: arxiv_datastore)
-        ARANGO_RO_SOCKET: Read-only Unix socket path
-        ARANGO_RW_SOCKET: Read-write Unix socket path
-        HADES_PDF_PATH: Base path for PDF storage
-        HADES_USE_GPU: Whether to use GPU (default: true)
-        CUDA_VISIBLE_DEVICES: GPU device selection
+        ARANGO_RO_SOCKET: Read-only Unix socket path for ArangoDB
+        ARANGO_RW_SOCKET: Read-write Unix socket path for ArangoDB
+        HADES_PDF_PATH: Base path for arxiv PDF storage
+        HADES_LATEX_PATH: Base path for arxiv LaTeX source storage
+        HADES_USE_GPU: Whether to use GPU for embeddings (true/false)
+        HADES_EMBEDDER_SOCKET: Embedding service Unix socket path
+
+    Note:
+        CUDA_VISIBLE_DEVICES is handled separately by the CLI layer
+        (see _set_gpu in main.py) before this function is called.
 
     Returns:
         CLIConfig with resolved values
@@ -53,38 +187,107 @@ def get_config() -> CLIConfig:
     Raises:
         ValueError: If required environment variables are missing
     """
+    # Load YAML defaults
+    yaml_config = _load_yaml_config(config_path)
+
+    # Get password (required, env only - never in YAML for security)
     password = os.environ.get("ARANGO_PASSWORD")
     if not password:
         raise ValueError("ARANGO_PASSWORD environment variable is required")
 
-    # Determine device
-    # When CUDA_VISIBLE_DEVICES is set, PyTorch sees devices as 0, 1, 2...
-    # regardless of the actual GPU indices. So we always use "cuda:0" or "cuda"
-    use_gpu = os.environ.get("HADES_USE_GPU", "true").lower() in ("true", "1", "yes")
+    # Determine device from env or YAML
+    use_gpu_env = os.environ.get("HADES_USE_GPU")
+    if use_gpu_env is not None:
+        use_gpu = use_gpu_env.lower() in ("true", "1", "yes")
+    else:
+        use_gpu = _get_nested(yaml_config, "gpu", "enabled", default=True)
 
     if use_gpu:
-        device = "cuda"  # PyTorch will use the first visible GPU
+        device = _get_nested(yaml_config, "gpu", "device", default="cuda")
     else:
         device = "cpu"
 
     # Parse port with validation
-    port_str = os.environ.get("ARANGO_PORT", "8529")
+    port_str = os.environ.get("ARANGO_PORT") or str(
+        _get_nested(yaml_config, "database", "port", default=8529)
+    )
     try:
         arango_port = int(port_str)
     except ValueError as e:
         raise ValueError(f"ARANGO_PORT must be a number, got: {port_str}") from e
 
+    # Build embedding config
+    embedding_yaml = yaml_config.get("embedding", {})
+    embedding_config = EmbeddingConfig(
+        service_socket=os.environ.get("HADES_EMBEDDER_SOCKET")
+        or _get_nested(embedding_yaml, "service", "socket", default="/run/hades/embedder.sock"),
+        fallback_to_local=_get_nested(embedding_yaml, "service", "fallback_to_local", default=True),
+        timeout_ms=_get_nested(embedding_yaml, "service", "timeout_ms", default=30000),
+        model_name=_get_nested(embedding_yaml, "model", "name", default="jinaai/jina-embeddings-v4"),
+        dimension=_get_nested(embedding_yaml, "model", "dimension", default=2048),
+        max_tokens=_get_nested(embedding_yaml, "model", "max_tokens", default=32768),
+        use_fp16=_get_nested(embedding_yaml, "model", "use_fp16", default=True),
+        normalize=_get_nested(embedding_yaml, "model", "normalize", default=True),
+        batch_size=_get_nested(embedding_yaml, "batch", "size", default=48),
+        batch_size_small=_get_nested(embedding_yaml, "batch", "size_small", default=8),
+        chunk_size_tokens=_get_nested(embedding_yaml, "chunking", "size_tokens", default=500),
+        chunk_overlap_tokens=_get_nested(embedding_yaml, "chunking", "overlap_tokens", default=200),
+    )
+
+    # Build search config
+    search_yaml = yaml_config.get("search", {})
+    search_config = SearchConfig(
+        limit=_get_nested(search_yaml, "limit", default=10),
+        max_limit=_get_nested(search_yaml, "max_limit", default=100),
+        hybrid_vector_weight=_get_nested(search_yaml, "hybrid", "vector_weight", default=0.7),
+        hybrid_keyword_weight=_get_nested(search_yaml, "hybrid", "keyword_weight", default=0.3),
+    )
+
+    # Build rocchio config (use _get_nested to safely handle non-dict values)
+    rocchio_config = RocchioConfig(
+        alpha=_get_nested(yaml_config, "rocchio", "alpha", default=1.0),
+        beta=_get_nested(yaml_config, "rocchio", "beta", default=0.75),
+        gamma=_get_nested(yaml_config, "rocchio", "gamma", default=0.15),
+    )
+
+    # Build sync config (use _get_nested to safely handle non-dict values)
+    sync_config = SyncConfig(
+        default_lookback_days=_get_nested(yaml_config, "sync", "default_lookback_days", default=7),
+        batch_size=_get_nested(yaml_config, "sync", "batch_size", default=8),
+        max_results=_get_nested(yaml_config, "sync", "max_results", default=1000),
+    )
+
+    # Socket paths: env overrides YAML
+    ro_socket = os.environ.get("ARANGO_RO_SOCKET") or _get_nested(
+        yaml_config, "database", "sockets", "readonly"
+    )
+    rw_socket = os.environ.get("ARANGO_RW_SOCKET") or _get_nested(
+        yaml_config, "database", "sockets", "readwrite"
+    )
+
     return CLIConfig(
         arango_password=password,
-        arango_host=os.environ.get("ARANGO_HOST", "localhost"),
+        arango_host=os.environ.get("ARANGO_HOST")
+        or _get_nested(yaml_config, "database", "host", default="localhost"),
         arango_port=arango_port,
-        arango_database=os.environ.get("HADES_DATABASE", "arxiv_datastore"),
-        arango_ro_socket=os.environ.get("ARANGO_RO_SOCKET"),
-        arango_rw_socket=os.environ.get("ARANGO_RW_SOCKET"),
-        pdf_base_path=Path(os.environ.get("HADES_PDF_PATH", "/bulk-store/arxiv-data/pdf")),
-        latex_base_path=Path(os.environ.get("HADES_LATEX_PATH", "/bulk-store/arxiv-data/src")),
+        arango_database=os.environ.get("HADES_DATABASE")
+        or _get_nested(yaml_config, "database", "database", default="arxiv_datastore"),
+        arango_ro_socket=ro_socket,
+        arango_rw_socket=rw_socket,
+        pdf_base_path=Path(
+            os.environ.get("HADES_PDF_PATH")
+            or _get_nested(yaml_config, "arxiv", "pdf_base_path", default="/bulk-store/arxiv-data/pdf")
+        ),
+        latex_base_path=Path(
+            os.environ.get("HADES_LATEX_PATH")
+            or _get_nested(yaml_config, "arxiv", "latex_base_path", default="/bulk-store/arxiv-data/src")
+        ),
         use_gpu=use_gpu,
         device=device,
+        embedding=embedding_config,
+        search=search_config,
+        rocchio=rocchio_config,
+        sync=sync_config,
     )
 
 

--- a/core/config/hades.yaml
+++ b/core/config/hades.yaml
@@ -1,0 +1,116 @@
+# HADES Configuration
+# ===================
+# Default configuration for the HADES knowledge base system.
+# Values can be overridden by environment variables or CLI arguments.
+#
+# Override priority (highest wins):
+#   1. CLI arguments (--gpu, --limit, etc.)
+#   2. Environment variables (HADES_*, ARANGO_*)
+#   3. This config file
+
+# -----------------------------------------------------------------------------
+# Database Configuration
+# -----------------------------------------------------------------------------
+database:
+  # ArangoDB connection settings
+  host: localhost
+  port: 8529
+  database: arxiv_datastore
+  username: root
+  # password: Set via ARANGO_PASSWORD environment variable (required)
+
+  # Unix socket paths for high-performance local connections
+  # These override host:port when set
+  sockets:
+    readonly: /run/hades/readonly/arangod.sock
+    readwrite: /run/hades/readwrite/arangod.sock
+
+# -----------------------------------------------------------------------------
+# Embedding Service Configuration
+# -----------------------------------------------------------------------------
+embedding:
+  # Service socket for persistent embedder daemon
+  service:
+    socket: /run/hades/embedder.sock
+    # Fallback to local model if service unavailable
+    fallback_to_local: true
+    # Timeout for service requests (milliseconds)
+    timeout_ms: 30000
+
+  # Model settings (used by service and local fallback)
+  model:
+    name: jinaai/jina-embeddings-v4
+    dimension: 2048
+    max_tokens: 32768
+    use_fp16: true
+    normalize: true
+
+  # Default batch processing settings
+  batch:
+    size: 48          # Optimal for A6000/A100 GPUs
+    size_small: 8     # Conservative for 16GB GPUs
+
+  # Late chunking configuration
+  chunking:
+    size_tokens: 500
+    overlap_tokens: 200
+
+# -----------------------------------------------------------------------------
+# GPU Configuration
+# -----------------------------------------------------------------------------
+gpu:
+  # Default device (cuda, cpu, or specific device like cuda:0)
+  device: cuda
+  # Use GPU by default
+  enabled: true
+
+# -----------------------------------------------------------------------------
+# Search Defaults
+# -----------------------------------------------------------------------------
+search:
+  # Default number of results
+  limit: 10
+  # Maximum allowed results
+  max_limit: 100
+  # Hybrid search settings
+  hybrid:
+    # Weight for vector similarity (0-1)
+    vector_weight: 0.7
+    # Weight for keyword matching (0-1)
+    keyword_weight: 0.3
+
+# -----------------------------------------------------------------------------
+# Relevance Feedback (Rocchio Algorithm)
+# -----------------------------------------------------------------------------
+rocchio:
+  # Weight for original query
+  alpha: 1.0
+  # Weight for positive exemplars
+  beta: 0.75
+  # Weight for negative exemplars
+  gamma: 0.15
+
+# -----------------------------------------------------------------------------
+# Sync Settings
+# -----------------------------------------------------------------------------
+sync:
+  # Default lookback period for incremental sync (days)
+  default_lookback_days: 7
+  # Default batch size for embedding during sync
+  batch_size: 8
+  # Default max results per sync
+  max_results: 1000
+
+# -----------------------------------------------------------------------------
+# ArXiv Data Paths
+# -----------------------------------------------------------------------------
+arxiv:
+  pdf_base_path: /bulk-store/arxiv-data/pdf
+  latex_base_path: /bulk-store/arxiv-data/src
+
+# -----------------------------------------------------------------------------
+# Logging
+# -----------------------------------------------------------------------------
+logging:
+  level: INFO
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/core/cli/test_config.py
+++ b/tests/core/cli/test_config.py
@@ -1,0 +1,353 @@
+"""Tests for HADES CLI configuration loading."""
+
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+import pytest
+
+from core.cli.config import (
+    CLIConfig,
+    EmbeddingConfig,
+    RocchioConfig,
+    SearchConfig,
+    SyncConfig,
+    _get_nested,
+    _load_yaml_config,
+    get_config,
+)
+
+
+class TestGetNested:
+    """Tests for _get_nested helper function."""
+
+    def test_gets_simple_value(self):
+        """Test getting a simple top-level value."""
+        config = {"key": "value"}
+        assert _get_nested(config, "key") == "value"
+
+    def test_gets_nested_value(self):
+        """Test getting a nested value."""
+        config = {"level1": {"level2": {"level3": "deep_value"}}}
+        assert _get_nested(config, "level1", "level2", "level3") == "deep_value"
+
+    def test_returns_default_for_missing_key(self):
+        """Test returns default when key is missing."""
+        config = {"key": "value"}
+        assert _get_nested(config, "missing", default="default") == "default"
+
+    def test_returns_default_for_missing_nested_key(self):
+        """Test returns default when nested key is missing."""
+        config = {"level1": {"level2": "value"}}
+        assert _get_nested(config, "level1", "missing", default="default") == "default"
+
+    def test_returns_none_as_default(self):
+        """Test returns None as default when not specified."""
+        config = {}
+        assert _get_nested(config, "missing") is None
+
+    def test_handles_non_dict_intermediate(self):
+        """Test handles non-dict intermediate value gracefully."""
+        config = {"level1": "not_a_dict"}
+        assert _get_nested(config, "level1", "level2", default="default") == "default"
+
+
+class TestLoadYamlConfig:
+    """Tests for YAML config loading."""
+
+    def test_loads_existing_yaml(self):
+        """Test loading an existing YAML file."""
+        with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("database:\n  host: testhost\n  port: 9999\n")
+            f.flush()
+            try:
+                config = _load_yaml_config(Path(f.name))
+                assert config["database"]["host"] == "testhost"
+                assert config["database"]["port"] == 9999
+            finally:
+                os.unlink(f.name)
+
+    def test_returns_empty_dict_for_missing_file(self):
+        """Test returns empty dict when file doesn't exist."""
+        config = _load_yaml_config(Path("/nonexistent/path/config.yaml"))
+        assert config == {}
+
+    def test_returns_empty_dict_for_empty_file(self):
+        """Test returns empty dict for empty YAML file."""
+        with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("")
+            f.flush()
+            try:
+                config = _load_yaml_config(Path(f.name))
+                assert config == {}
+            finally:
+                os.unlink(f.name)
+
+    def test_raises_error_for_list_yaml(self):
+        """Test raises TypeError when YAML contains a list instead of dict."""
+        with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("- item1\n- item2\n- item3\n")
+            f.flush()
+            try:
+                with pytest.raises(TypeError, match="must contain a YAML mapping"):
+                    _load_yaml_config(Path(f.name))
+            finally:
+                os.unlink(f.name)
+
+    def test_raises_error_for_scalar_yaml(self):
+        """Test raises TypeError when YAML contains a scalar instead of dict."""
+        with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("just a string value\n")
+            f.flush()
+            try:
+                with pytest.raises(TypeError, match="got str"):
+                    _load_yaml_config(Path(f.name))
+            finally:
+                os.unlink(f.name)
+
+
+class TestGetConfig:
+    """Tests for get_config function."""
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_requires_arango_password(self):
+        """Test that ARANGO_PASSWORD is required."""
+        # Create a minimal config to avoid hitting the actual file
+        with patch("core.cli.config._load_yaml_config", return_value={}):
+            config = get_config()
+            assert config.arango_password == "testpass"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_raises_without_password(self):
+        """Test raises ValueError without ARANGO_PASSWORD."""
+        with patch("core.cli.config._load_yaml_config", return_value={}):
+            with pytest.raises(ValueError, match="ARANGO_PASSWORD"):
+                get_config()
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_loads_database_config_from_yaml(self):
+        """Test database config is loaded from YAML."""
+        yaml_config = {
+            "database": {
+                "host": "yaml-host",
+                "port": 9999,
+                "database": "yaml-db",
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.arango_host == "yaml-host"
+            assert config.arango_port == 9999
+            assert config.arango_database == "yaml-db"
+
+    @patch.dict(
+        os.environ,
+        {
+            "ARANGO_PASSWORD": "testpass",
+            "ARANGO_HOST": "env-host",
+            "ARANGO_PORT": "8888",
+            "HADES_DATABASE": "env-db",
+        },
+        clear=True,
+    )
+    def test_env_overrides_yaml(self):
+        """Test environment variables override YAML values."""
+        yaml_config = {
+            "database": {
+                "host": "yaml-host",
+                "port": 9999,
+                "database": "yaml-db",
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.arango_host == "env-host"
+            assert config.arango_port == 8888
+            assert config.arango_database == "env-db"
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_loads_embedding_config(self):
+        """Test embedding config is loaded from YAML."""
+        yaml_config = {
+            "embedding": {
+                "service": {
+                    "socket": "/custom/socket.sock",
+                    "fallback_to_local": False,
+                    "timeout_ms": 60000,
+                },
+                "model": {
+                    "name": "custom-model",
+                    "dimension": 1024,
+                },
+                "batch": {
+                    "size": 64,
+                    "size_small": 16,
+                },
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.embedding.service_socket == "/custom/socket.sock"
+            assert config.embedding.fallback_to_local is False
+            assert config.embedding.timeout_ms == 60000
+            assert config.embedding.model_name == "custom-model"
+            assert config.embedding.dimension == 1024
+            assert config.embedding.batch_size == 64
+            assert config.embedding.batch_size_small == 16
+
+    @patch.dict(
+        os.environ, {"ARANGO_PASSWORD": "testpass", "HADES_EMBEDDER_SOCKET": "/env/socket.sock"}, clear=True
+    )
+    def test_env_overrides_embedding_socket(self):
+        """Test HADES_EMBEDDER_SOCKET overrides YAML value."""
+        yaml_config = {
+            "embedding": {
+                "service": {
+                    "socket": "/yaml/socket.sock",
+                }
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.embedding.service_socket == "/env/socket.sock"
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_loads_search_config(self):
+        """Test search config is loaded from YAML."""
+        yaml_config = {
+            "search": {
+                "limit": 25,
+                "max_limit": 200,
+                "hybrid": {
+                    "vector_weight": 0.8,
+                    "keyword_weight": 0.2,
+                },
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.search.limit == 25
+            assert config.search.max_limit == 200
+            assert config.search.hybrid_vector_weight == 0.8
+            assert config.search.hybrid_keyword_weight == 0.2
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_loads_rocchio_config(self):
+        """Test rocchio config is loaded from YAML."""
+        yaml_config = {
+            "rocchio": {
+                "alpha": 0.5,
+                "beta": 0.8,
+                "gamma": 0.2,
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.rocchio.alpha == 0.5
+            assert config.rocchio.beta == 0.8
+            assert config.rocchio.gamma == 0.2
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_loads_sync_config(self):
+        """Test sync config is loaded from YAML."""
+        yaml_config = {
+            "sync": {
+                "default_lookback_days": 14,
+                "batch_size": 16,
+                "max_results": 2000,
+            }
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.sync.default_lookback_days == 14
+            assert config.sync.batch_size == 16
+            assert config.sync.max_results == 2000
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_handles_non_dict_rocchio_and_sync(self):
+        """Test gracefully handles non-dict values for rocchio and sync sections."""
+        yaml_config = {
+            "rocchio": "not a dict",  # Invalid: should be a mapping
+            "sync": ["also", "not", "a", "dict"],  # Invalid: should be a mapping
+        }
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            # Should fall back to defaults when sections are non-dict
+            assert config.rocchio.alpha == 1.0
+            assert config.rocchio.beta == 0.75
+            assert config.rocchio.gamma == 0.15
+            assert config.sync.default_lookback_days == 7
+            assert config.sync.batch_size == 8
+            assert config.sync.max_results == 1000
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_uses_defaults_when_yaml_missing(self):
+        """Test uses dataclass defaults when YAML values missing."""
+        with patch("core.cli.config._load_yaml_config", return_value={}):
+            config = get_config()
+            # Check defaults are used
+            assert config.arango_host == "localhost"
+            assert config.arango_port == 8529
+            assert config.embedding.dimension == 2048
+            assert config.search.limit == 10
+            assert config.rocchio.alpha == 1.0
+            assert config.sync.default_lookback_days == 7
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass", "HADES_USE_GPU": "false"}, clear=True)
+    def test_gpu_disabled_via_env(self):
+        """Test GPU can be disabled via environment variable."""
+        with patch("core.cli.config._load_yaml_config", return_value={}):
+            config = get_config()
+            assert config.use_gpu is False
+            assert config.device == "cpu"
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass"}, clear=True)
+    def test_gpu_disabled_via_yaml(self):
+        """Test GPU can be disabled via YAML."""
+        yaml_config = {"gpu": {"enabled": False}}
+        with patch("core.cli.config._load_yaml_config", return_value=yaml_config):
+            config = get_config()
+            assert config.use_gpu is False
+            assert config.device == "cpu"
+
+    @patch.dict(os.environ, {"ARANGO_PASSWORD": "testpass", "ARANGO_PORT": "invalid"}, clear=True)
+    def test_invalid_port_raises_error(self):
+        """Test invalid port value raises ValueError."""
+        with patch("core.cli.config._load_yaml_config", return_value={}):
+            with pytest.raises(ValueError, match="ARANGO_PORT must be a number"):
+                get_config()
+
+
+class TestConfigDataclasses:
+    """Tests for config dataclass defaults."""
+
+    def test_embedding_config_defaults(self):
+        """Test EmbeddingConfig has sensible defaults."""
+        config = EmbeddingConfig()
+        assert config.service_socket == "/run/hades/embedder.sock"
+        assert config.fallback_to_local is True
+        assert config.model_name == "jinaai/jina-embeddings-v4"
+        assert config.dimension == 2048
+        assert config.batch_size == 48
+
+    def test_search_config_defaults(self):
+        """Test SearchConfig has sensible defaults."""
+        config = SearchConfig()
+        assert config.limit == 10
+        assert config.max_limit == 100
+        assert config.hybrid_vector_weight == 0.7
+
+    def test_rocchio_config_defaults(self):
+        """Test RocchioConfig has sensible defaults."""
+        config = RocchioConfig()
+        assert config.alpha == 1.0
+        assert config.beta == 0.75
+        assert config.gamma == 0.15
+
+    def test_sync_config_defaults(self):
+        """Test SyncConfig has sensible defaults."""
+        config = SyncConfig()
+        assert config.default_lookback_days == 7
+        assert config.batch_size == 8
+        assert config.max_results == 1000


### PR DESCRIPTION
## Summary
- Add central YAML configuration file (`core/config/hades.yaml`) as the repository of default behaviors
- Update `config.py` to load from YAML first, with environment variable overrides
- Add nested dataclasses (`EmbeddingConfig`, `SearchConfig`, `RocchioConfig`, `SyncConfig`) for organized config access
- Add 26 unit tests for config loading behavior

## Configuration Hierarchy
Override priority (highest wins):
1. **CLI arguments** (`--gpu`, `--limit`, etc.)
2. **Environment variables** (`HADES_*`, `ARANGO_*`)
3. **YAML config file** (`core/config/hades.yaml`)

## YAML Config Sections
- `database` - ArangoDB connection settings and Unix socket paths
- `embedding` - Embedding service socket, model settings, batch sizes, chunking
- `gpu` - Device selection and enabled flag
- `search` - Default limits and hybrid search weights
- `rocchio` - Relevance feedback algorithm weights
- `sync` - Incremental sync defaults
- `arxiv` - PDF and LaTeX storage paths

## Test plan
- [x] All 26 new config tests pass
- [x] All 82 CLI tests pass (no regressions)
- [x] Verify YAML loads correctly with `from core.cli.config import get_config`
- [x] Verify env vars override YAML values
- [x] Verify missing YAML falls back to dataclass defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YAML-driven configuration with layered overrides (CLI > environment > YAML > defaults) and optional custom config path; grouped nested settings for embedding, search, Rocchio feedback, and sync.

* **Bug Fixes / Validation**
  * Stronger type and presence validation for critical settings and improved environment-variable override handling for nested options.

* **Tests**
  * Comprehensive unit tests covering loading, precedence, nested retrieval, defaults, and error cases.

* **Chores**
  * Added a documented default config file with sensible defaults and precedence notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->