### PR TITLE
Fix embedder client rejecting idle service as unavailable

### DIFF
--- a/core/services/embedder_client.py
+++ b/core/services/embedder_client.py
@@ -104,7 +104,7 @@ class EmbedderClient:
             response = self._get_client().get("/health")
             if response.status_code == 200:
                 data = response.json()
-                self._service_available = data.get("status") == "ready"
+                self._service_available = data.get("status") in ("ready", "idle")
             else:
                 self._service_available = False
         except Exception as e:


### PR DESCRIPTION
## Summary
- The idle-unload feature (PR #35) introduced health status `"idle"` when the model is unloaded to save VRAM
- `EmbedderClient.is_service_available()` only accepted `"ready"`, so it treated a running-but-idle service as dead and raised `EmbedderServiceError` instead of sending the request (which would trigger auto-load)
- Fix: accept both `"ready"` and `"idle"` as available statuses

## Test plan
- [ ] Start embedding service, wait for model to idle-unload (15 min timeout)
- [ ] Verify `/health` returns `status: "idle"`, `model_loaded: false`
- [ ] Run `hades database query "test" --paper <id>` — should succeed, model auto-loads
- [ ] Verify `/health` now returns `status: "ready"`, `model_loaded: true`
- [ ] `poetry run pytest tests/core/ -x -q` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding service availability detection to recognize additional healthy states, enhancing overall service reliability and reducing unnecessary unavailability windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->