### PR TITLE
Add DatabaseClient service following EmbedderClient pattern

### DIFF
--- a/core/services/database_client.py
+++ b/core/services/database_client.py
@@ -1,0 +1,368 @@
+"""HADES Database Service Client.
+
+Client library for communicating with ArangoDB over Unix socket.
+Provides health checks, service availability detection, and graceful fallback.
+
+Usage:
+    from core.services import DatabaseClient
+
+    with DatabaseClient() as client:
+        if client.is_service_available():
+            result = client.query("FOR doc IN collection RETURN doc")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.database.arango.optimized_client import ArangoHttp2Client
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseServiceError(Exception):
+    """Error communicating with the database service."""
+
+    pass
+
+
+@dataclass
+class DatabaseClientConfig:
+    """Configuration for the database client.
+
+    Attributes:
+        ro_socket_path: Path to the read-only Unix socket
+        rw_socket_path: Path to the read-write Unix socket
+        fallback_to_http: Whether to fall back to HTTP if socket unavailable
+        http_host: HTTP fallback host
+        http_port: HTTP fallback port
+        database: Database name to use
+        username: Authentication username
+        password: Authentication password
+        connect_timeout: Connection timeout in seconds
+        read_timeout: Read timeout in seconds
+    """
+
+    ro_socket_path: str | None = None
+    rw_socket_path: str | None = None
+    fallback_to_http: bool = True
+    http_host: str = "localhost"
+    http_port: int = 8529
+    database: str = "_system"
+    username: str | None = None
+    password: str | None = None
+    connect_timeout: float = 5.0
+    read_timeout: float = 30.0
+
+    def __post_init__(self):
+        """Set default socket paths from environment variables."""
+        if self.ro_socket_path is None:
+            self.ro_socket_path = os.environ.get(
+                "ARANGO_RO_SOCKET", "/run/hades/readonly/arangod.sock"
+            )
+        if self.rw_socket_path is None:
+            self.rw_socket_path = os.environ.get(
+                "ARANGO_RW_SOCKET", "/run/hades/readwrite/arangod.sock"
+            )
+        if self.password is None:
+            self.password = os.environ.get("ARANGO_PASSWORD")
+        if self.username is None:
+            self.username = os.environ.get("ARANGO_USERNAME", "root")
+
+
+class DatabaseClient:
+    """Client for the HADES database service.
+
+    Provides health checking, service availability detection, and graceful
+    fallback from Unix socket to HTTP connection.
+
+    Attributes:
+        config: Client configuration
+        read_only: Whether to use read-only connection
+
+    Example:
+        with DatabaseClient() as client:
+            if client.is_service_available():
+                health = client.get_health()
+                print(f"Database latency: {health['latency_ms']}ms")
+    """
+
+    def __init__(
+        self,
+        config: DatabaseClientConfig | None = None,
+        read_only: bool = True,
+    ) -> None:
+        """Initialize the database client.
+
+        Args:
+            config: Client configuration (uses defaults if not provided)
+            read_only: Use read-only socket (default True)
+        """
+        self.config = config or DatabaseClientConfig()
+        self.read_only = read_only
+
+        self._client: ArangoHttp2Client | None = None
+        self._service_available: bool | None = None
+        self._using_socket: bool = True
+
+    def _get_socket_path(self) -> str | None:
+        """Get the appropriate socket path based on read_only setting."""
+        if self.read_only:
+            return self.config.ro_socket_path
+        return self.config.rw_socket_path
+
+    def _create_client(self, use_socket: bool = True) -> ArangoHttp2Client:
+        """Create an ArangoDB client.
+
+        Args:
+            use_socket: Whether to use Unix socket (True) or HTTP (False)
+
+        Returns:
+            Configured ArangoHttp2Client instance
+        """
+        from core.database.arango.optimized_client import (
+            ArangoHttp2Client,
+            ArangoHttp2Config,
+        )
+
+        socket_path = self._get_socket_path() if use_socket else None
+
+        if use_socket and socket_path:
+            base_url = "http://localhost"
+        else:
+            base_url = f"http://{self.config.http_host}:{self.config.http_port}"
+
+        arango_config = ArangoHttp2Config(
+            database=self.config.database,
+            socket_path=socket_path if use_socket else None,
+            base_url=base_url,
+            username=self.config.username,
+            password=self.config.password,
+            connect_timeout=self.config.connect_timeout,
+            read_timeout=self.config.read_timeout,
+        )
+
+        return ArangoHttp2Client(arango_config)
+
+    def _get_client(self) -> ArangoHttp2Client:
+        """Get or create the ArangoDB client with fallback support.
+
+        Returns:
+            Active ArangoHttp2Client instance
+
+        Raises:
+            DatabaseServiceError: If no connection can be established
+        """
+        if self._client is not None:
+            return self._client
+
+        # Try socket connection first
+        socket_path = self._get_socket_path()
+        if socket_path and os.path.exists(socket_path):
+            try:
+                self._client = self._create_client(use_socket=True)
+                self._using_socket = True
+                logger.debug(f"Connected via Unix socket: {socket_path}")
+                return self._client
+            except Exception as e:
+                logger.warning(f"Socket connection failed: {e}")
+                if not self.config.fallback_to_http:
+                    raise DatabaseServiceError(f"Socket connection failed: {e}") from e
+
+        # Fall back to HTTP if enabled
+        if self.config.fallback_to_http:
+            try:
+                self._client = self._create_client(use_socket=False)
+                self._using_socket = False
+                logger.info(
+                    f"Connected via HTTP fallback: "
+                    f"{self.config.http_host}:{self.config.http_port}"
+                )
+                return self._client
+            except Exception as e:
+                raise DatabaseServiceError(f"HTTP connection failed: {e}") from e
+
+        raise DatabaseServiceError(
+            f"Database unavailable: socket {socket_path} does not exist "
+            "and HTTP fallback is disabled"
+        )
+
+    def is_service_available(self, force_check: bool = False) -> bool:
+        """Check if the database service is available.
+
+        Args:
+            force_check: Force a fresh check instead of using cached result
+
+        Returns:
+            True if database is available and responding
+        """
+        if self._service_available is not None and not force_check:
+            return self._service_available
+
+        try:
+            # Try to get server version as health check
+            client = self._get_client()
+            response = client._client.get("/_api/version")
+            self._service_available = response.status_code == 200
+        except Exception as e:
+            logger.debug(f"Service availability check failed: {e}")
+            self._service_available = False
+
+        return self._service_available
+
+    def get_health(self) -> dict[str, Any]:
+        """Get database health information.
+
+        Returns:
+            Health response dict with:
+            - available: Whether database is responding
+            - latency_ms: Round-trip latency in milliseconds
+            - server_version: ArangoDB server version
+            - connection_type: 'socket' or 'http'
+            - database: Current database name
+            - engine: Storage engine (rocksdb, etc.)
+
+        Raises:
+            DatabaseServiceError: If health check fails
+        """
+        try:
+            client = self._get_client()
+
+            # Measure latency with version endpoint
+            start = time.time()
+            response = client._client.get("/_api/version")
+            latency_ms = (time.time() - start) * 1000
+
+            if response.status_code != 200:
+                raise DatabaseServiceError(
+                    f"Health check failed with status {response.status_code}"
+                )
+
+            data = response.json()
+
+            # Get engine info
+            engine_response = client._client.get("/_api/engine")
+            engine_info = {}
+            if engine_response.status_code == 200:
+                engine_info = engine_response.json()
+
+            return {
+                "available": True,
+                "latency_ms": round(latency_ms, 2),
+                "server_version": data.get("version", "unknown"),
+                "server_license": data.get("license", "unknown"),
+                "connection_type": "socket" if self._using_socket else "http",
+                "socket_path": self._get_socket_path() if self._using_socket else None,
+                "database": self.config.database,
+                "engine": engine_info.get("name", "unknown"),
+            }
+
+        except DatabaseServiceError:
+            raise
+        except Exception as e:
+            raise DatabaseServiceError(f"Health check failed: {e}") from e
+
+    def query(
+        self,
+        aql: str,
+        bind_vars: dict[str, Any] | None = None,
+        batch_size: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Execute an AQL query.
+
+        Args:
+            aql: AQL query string
+            bind_vars: Query bind variables
+            batch_size: Cursor batch size
+
+        Returns:
+            List of result documents
+
+        Raises:
+            DatabaseServiceError: If query fails
+        """
+        try:
+            client = self._get_client()
+            return client.query(aql, bind_vars=bind_vars, batch_size=batch_size)
+        except Exception as e:
+            raise DatabaseServiceError(f"Query failed: {e}") from e
+
+    def get_document(self, collection: str, key: str) -> dict[str, Any]:
+        """Fetch a single document by collection and key.
+
+        Args:
+            collection: Collection name
+            key: Document key
+
+        Returns:
+            Document data
+
+        Raises:
+            DatabaseServiceError: If document fetch fails
+        """
+        try:
+            client = self._get_client()
+            return client.get_document(collection, key)
+        except Exception as e:
+            raise DatabaseServiceError(f"Document fetch failed: {e}") from e
+
+    def get_client(self) -> ArangoHttp2Client:
+        """Get the underlying ArangoDB client for direct access.
+
+        Returns:
+            The ArangoHttp2Client instance
+
+        Note:
+            Use this for operations not wrapped by DatabaseClient.
+            The client is managed by DatabaseClient - don't close it directly.
+        """
+        return self._get_client()
+
+    def close(self) -> None:
+        """Close the client and release resources."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+            self._service_available = None
+
+    def __enter__(self) -> DatabaseClient:
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Context manager exit."""
+        self.close()
+
+    def __del__(self) -> None:
+        """Cleanup on deletion."""
+        self.close()
+
+
+# Convenience function for quick health check
+def check_database_health(
+    ro_socket_path: str | None = None,
+    fallback_to_http: bool = True,
+) -> dict[str, Any]:
+    """Check database health using a temporary client.
+
+    Args:
+        ro_socket_path: Path to read-only socket (uses default if None)
+        fallback_to_http: Fall back to HTTP if socket unavailable
+
+    Returns:
+        Health information dict
+
+    Raises:
+        DatabaseServiceError: If health check fails
+    """
+    config = DatabaseClientConfig(
+        ro_socket_path=ro_socket_path,
+        fallback_to_http=fallback_to_http,
+    )
+    with DatabaseClient(config=config) as client:
+        return client.get_health()

--- a/tests/core/services/test_database_client.py
+++ b/tests/core/services/test_database_client.py
@@ -1,0 +1,416 @@
+"""Unit tests for DatabaseClient.
+
+Tests for:
+- Configuration initialization
+- Service availability checking
+- Health check functionality
+- Context manager support
+- Fallback behavior
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestDatabaseClientConfig:
+    """Tests for DatabaseClientConfig initialization."""
+
+    def test_default_values(self):
+        """Should use default values when not specified."""
+        from core.services.database_client import DatabaseClientConfig
+
+        # Clear environment variables for clean test
+        with patch.dict("os.environ", {}, clear=True):
+            config = DatabaseClientConfig()
+
+        assert config.fallback_to_http is True
+        assert config.http_host == "localhost"
+        assert config.http_port == 8529
+        assert config.database == "_system"
+        assert config.connect_timeout == 5.0
+        assert config.read_timeout == 30.0
+
+    def test_reads_from_environment(self):
+        """Should read socket paths and password from environment."""
+        from core.services.database_client import DatabaseClientConfig
+
+        env_vars = {
+            "ARANGO_RO_SOCKET": "/custom/ro.sock",
+            "ARANGO_RW_SOCKET": "/custom/rw.sock",
+            "ARANGO_PASSWORD": "secret123",
+            "ARANGO_USERNAME": "admin",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            config = DatabaseClientConfig()
+
+        assert config.ro_socket_path == "/custom/ro.sock"
+        assert config.rw_socket_path == "/custom/rw.sock"
+        assert config.password == "secret123"
+        assert config.username == "admin"
+
+    def test_explicit_values_override_environment(self):
+        """Should use explicit values over environment variables."""
+        from core.services.database_client import DatabaseClientConfig
+
+        env_vars = {
+            "ARANGO_RO_SOCKET": "/env/ro.sock",
+            "ARANGO_PASSWORD": "env_password",
+        }
+        with patch.dict("os.environ", env_vars, clear=True):
+            config = DatabaseClientConfig(
+                ro_socket_path="/explicit/ro.sock",
+                password="explicit_password",
+            )
+
+        assert config.ro_socket_path == "/explicit/ro.sock"
+        assert config.password == "explicit_password"
+
+
+class TestDatabaseClientInit:
+    """Tests for DatabaseClient initialization."""
+
+    def test_default_config(self):
+        """Should initialize with default configuration."""
+        from core.services.database_client import DatabaseClient
+
+        with patch.dict("os.environ", {}, clear=True):
+            client = DatabaseClient()
+
+        assert client.config is not None
+        assert client.read_only is True
+        assert client._client is None
+        assert client._service_available is None
+
+    def test_custom_config(self):
+        """Should accept custom configuration."""
+        from core.services.database_client import (
+            DatabaseClient,
+            DatabaseClientConfig,
+        )
+
+        config = DatabaseClientConfig(
+            database="test_db",
+            http_port=8530,
+        )
+        client = DatabaseClient(config=config, read_only=False)
+
+        assert client.config.database == "test_db"
+        assert client.config.http_port == 8530
+        assert client.read_only is False
+
+    def test_get_socket_path_read_only(self):
+        """Should return read-only socket path when read_only=True."""
+        from core.services.database_client import (
+            DatabaseClient,
+            DatabaseClientConfig,
+        )
+
+        config = DatabaseClientConfig(
+            ro_socket_path="/ro.sock",
+            rw_socket_path="/rw.sock",
+        )
+        client = DatabaseClient(config=config, read_only=True)
+
+        assert client._get_socket_path() == "/ro.sock"
+
+    def test_get_socket_path_read_write(self):
+        """Should return read-write socket path when read_only=False."""
+        from core.services.database_client import (
+            DatabaseClient,
+            DatabaseClientConfig,
+        )
+
+        config = DatabaseClientConfig(
+            ro_socket_path="/ro.sock",
+            rw_socket_path="/rw.sock",
+        )
+        client = DatabaseClient(config=config, read_only=False)
+
+        assert client._get_socket_path() == "/rw.sock"
+
+
+class TestDatabaseClientAvailability:
+    """Tests for service availability checking."""
+
+    def test_is_service_available_success(self):
+        """Should return True when database responds."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+
+        mock_http_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_http_client.get.return_value = mock_response
+
+        mock_arango_client = MagicMock()
+        mock_arango_client._client = mock_http_client
+        client._client = mock_arango_client
+
+        result = client.is_service_available()
+
+        assert result is True
+        assert client._service_available is True
+
+    def test_is_service_available_failure(self):
+        """Should return False when database doesn't respond."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+
+        mock_http_client = MagicMock()
+        mock_http_client.get.side_effect = Exception("Connection refused")
+
+        mock_arango_client = MagicMock()
+        mock_arango_client._client = mock_http_client
+        client._client = mock_arango_client
+
+        result = client.is_service_available()
+
+        assert result is False
+        assert client._service_available is False
+
+    def test_is_service_available_cached(self):
+        """Should return cached result without force_check."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+        client._service_available = True
+
+        # Should not make any calls
+        result = client.is_service_available()
+
+        assert result is True
+
+    def test_is_service_available_force_check(self):
+        """Should make fresh check when force_check=True."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+        client._service_available = True
+
+        mock_http_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_http_client.get.return_value = mock_response
+
+        mock_arango_client = MagicMock()
+        mock_arango_client._client = mock_http_client
+        client._client = mock_arango_client
+
+        result = client.is_service_available(force_check=True)
+
+        assert result is False
+        mock_http_client.get.assert_called_once()
+
+
+class TestDatabaseClientHealth:
+    """Tests for health check functionality."""
+
+    def test_get_health_success(self):
+        """Should return health info on success."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+        client._using_socket = True
+
+        mock_http_client = MagicMock()
+
+        # Version response
+        version_response = MagicMock()
+        version_response.status_code = 200
+        version_response.json.return_value = {
+            "version": "3.11.0",
+            "license": "community",
+        }
+
+        # Engine response
+        engine_response = MagicMock()
+        engine_response.status_code = 200
+        engine_response.json.return_value = {"name": "rocksdb"}
+
+        mock_http_client.get.side_effect = [version_response, engine_response]
+
+        mock_arango_client = MagicMock()
+        mock_arango_client._client = mock_http_client
+        client._client = mock_arango_client
+
+        health = client.get_health()
+
+        assert health["available"] is True
+        assert health["server_version"] == "3.11.0"
+        assert health["engine"] == "rocksdb"
+        assert health["connection_type"] == "socket"
+        assert "latency_ms" in health
+
+    def test_get_health_failure(self):
+        """Should raise DatabaseServiceError on failure."""
+        from core.services.database_client import (
+            DatabaseClient,
+            DatabaseServiceError,
+        )
+
+        client = DatabaseClient()
+
+        mock_http_client = MagicMock()
+        mock_http_client.get.side_effect = Exception("Connection failed")
+
+        mock_arango_client = MagicMock()
+        mock_arango_client._client = mock_http_client
+        client._client = mock_arango_client
+
+        import pytest
+
+        with pytest.raises(DatabaseServiceError, match="Health check failed"):
+            client.get_health()
+
+
+class TestDatabaseClientContextManager:
+    """Tests for context manager support."""
+
+    def test_context_manager_enter(self):
+        """Should return self on enter."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+
+        result = client.__enter__()
+
+        assert result is client
+
+    def test_context_manager_exit_closes_client(self):
+        """Should close client on exit."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+        mock_arango_client = MagicMock()
+        client._client = mock_arango_client
+
+        client.__exit__(None, None, None)
+
+        mock_arango_client.close.assert_called_once()
+        assert client._client is None
+
+    def test_context_manager_with_statement(self):
+        """Should work with 'with' statement."""
+        from core.services.database_client import DatabaseClient
+
+        with DatabaseClient() as client:
+            assert client is not None
+            # Client should be usable inside context
+
+
+class TestDatabaseClientFallback:
+    """Tests for fallback behavior."""
+
+    def test_falls_back_to_http_when_socket_unavailable(self):
+        """Should fall back to HTTP when socket doesn't exist."""
+        from core.services.database_client import (
+            DatabaseClient,
+            DatabaseClientConfig,
+        )
+
+        config = DatabaseClientConfig(
+            ro_socket_path="/nonexistent/socket.sock",
+            fallback_to_http=True,
+        )
+        client = DatabaseClient(config=config)
+
+        # Mock the HTTP client creation
+        with patch(
+            "core.services.database_client.DatabaseClient._create_client"
+        ) as mock_create:
+            mock_arango = MagicMock()
+            mock_create.return_value = mock_arango
+
+            client._get_client()
+
+            # Should have been called with use_socket=False (fallback)
+            assert mock_create.call_count >= 1
+            last_call = mock_create.call_args_list[-1]
+            assert last_call[1].get("use_socket") is False
+
+    def test_raises_error_when_fallback_disabled(self):
+        """Should raise error when socket unavailable and fallback disabled."""
+        from core.services.database_client import (
+            DatabaseClient,
+            DatabaseClientConfig,
+            DatabaseServiceError,
+        )
+
+        config = DatabaseClientConfig(
+            ro_socket_path="/nonexistent/socket.sock",
+            fallback_to_http=False,
+        )
+        client = DatabaseClient(config=config)
+
+        import pytest
+
+        with pytest.raises(DatabaseServiceError, match="does not exist"):
+            client._get_client()
+
+
+class TestDatabaseClientOperations:
+    """Tests for database operations."""
+
+    def test_query_delegates_to_client(self):
+        """Should delegate query to underlying client."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+
+        mock_arango_client = MagicMock()
+        mock_arango_client.query.return_value = [{"_key": "1"}]
+        client._client = mock_arango_client
+
+        result = client.query("FOR doc IN test RETURN doc")
+
+        mock_arango_client.query.assert_called_once()
+        assert result == [{"_key": "1"}]
+
+    def test_get_document_delegates_to_client(self):
+        """Should delegate get_document to underlying client."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+
+        mock_arango_client = MagicMock()
+        mock_arango_client.get_document.return_value = {"_key": "1", "name": "test"}
+        client._client = mock_arango_client
+
+        result = client.get_document("test_collection", "1")
+
+        mock_arango_client.get_document.assert_called_once_with("test_collection", "1")
+        assert result["name"] == "test"
+
+    def test_get_client_returns_underlying_client(self):
+        """Should return the underlying ArangoHttp2Client."""
+        from core.services.database_client import DatabaseClient
+
+        client = DatabaseClient()
+
+        mock_arango_client = MagicMock()
+        client._client = mock_arango_client
+
+        result = client.get_client()
+
+        assert result is mock_arango_client
+
+
+class TestConvenienceFunction:
+    """Tests for the convenience function."""
+
+    def test_check_database_health(self):
+        """Should return health info using temporary client."""
+        from core.services.database_client import check_database_health
+
+        with patch("core.services.database_client.DatabaseClient") as MockClient:
+            mock_instance = MagicMock()
+            mock_instance.get_health.return_value = {"available": True}
+            mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+            mock_instance.__exit__ = MagicMock(return_value=None)
+            MockClient.return_value = mock_instance
+
+            result = check_database_health()
+
+            assert result["available"] is True
+            mock_instance.get_health.assert_called_once()


### PR DESCRIPTION
## Summary
- Implements #54 - Database Health Service Client
- Creates `DatabaseClient` following the same pattern as `EmbedderClient`
- Provides health checking, service availability detection, and graceful fallback

## Changes
- **core/services/database_client.py**: New service client with:
  - `DatabaseClientConfig` dataclass for configuration
  - `is_service_available()` for availability checking with caching
  - `get_health()` returns latency, server version, connection type, engine info
  - Context manager support (`__enter__`/`__exit__`)
  - Graceful fallback from Unix socket to HTTP when socket unavailable
  - `query()` and `get_document()` operations
  - `check_database_health()` convenience function

- **tests/core/services/test_database_client.py**: 22 unit tests covering:
  - Configuration initialization and environment variable reading
  - Service availability checking with caching and force refresh
  - Health check functionality
  - Context manager support
  - Fallback behavior
  - Database operations delegation

## Test plan
- [x] `poetry run ruff check` passes
- [x] `poetry run pytest tests/core/services/test_database_client.py -v` (22 tests pass)

🤖 Generated with [Claude Code](https://claude.ai/code)