### PR TITLE
Add --collection flag to decouple db commands from arxiv

### DIFF
--- a/core/database/collections.py
+++ b/core/database/collections.py
@@ -8,10 +8,14 @@ Built-in profiles:
     arxiv       — ingested full papers (arxiv_metadata, arxiv_abstract_chunks, arxiv_abstract_embeddings)
     sync        — synced abstracts (arxiv_papers, arxiv_abstracts, arxiv_embeddings)
     default     — generic names (documents, chunks, embeddings)
+
+Environment variables:
+    HADES_DEFAULT_COLLECTION — default profile name (defaults to "arxiv")
 """
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 
@@ -61,3 +65,33 @@ def get_profile(name: str) -> CollectionProfile:
     except KeyError:
         available = ", ".join(sorted(PROFILES))
         raise KeyError(f"Unknown collection profile: {name!r}. Available: {available}") from None
+
+
+def get_default_profile_name() -> str:
+    """Get the default collection profile name.
+
+    Reads from HADES_DEFAULT_COLLECTION environment variable,
+    falling back to "arxiv" for backward compatibility.
+
+    Returns:
+        Profile name string
+    """
+    return os.environ.get("HADES_DEFAULT_COLLECTION", "arxiv")
+
+
+def get_default_profile() -> CollectionProfile:
+    """Get the default collection profile.
+
+    Returns:
+        CollectionProfile from environment or default (arxiv)
+    """
+    return get_profile(get_default_profile_name())
+
+
+def list_profiles() -> list[str]:
+    """List all available profile names.
+
+    Returns:
+        Sorted list of profile names
+    """
+    return sorted(PROFILES.keys())


### PR DESCRIPTION
## Summary
- Implements #72 - Decouples database commands from arxiv-specific assumptions
- All `hades db` commands now accept `--collection/-C` flag to specify which collection profile to query
- Backward compatible: defaults to `arxiv` collection

## Changes

### core/database/collections.py
- Added `get_default_profile_name()` - reads from `HADES_DEFAULT_COLLECTION` env var
- Added `get_default_profile()` - returns default CollectionProfile
- Added `list_profiles()` - returns available profile names

### core/cli/main.py
Updated commands with `--collection` option:
- `db query` - semantic search
- `db list` - list documents
- `db stats` - show statistics  
- `db check` - check document existence
- `db purge` - remove document

### core/cli/commands/database.py
Updated functions to accept `collection` parameter:
- `list_stored_papers()`
- `get_stats()`
- `check_paper_exists()` → also renamed `arxiv_id` → `document_id`
- `purge_paper()` → also renamed `arxiv_id` → `document_id`
- `semantic_query()`
- `get_paper_chunks()`
- `_search_embeddings()`
- `_search_with_decomposition()`
- `_add_context_chunks()`

## Usage Examples

```bash
# Query default collection (arxiv)
hades db query "attention mechanism"

# Query specific collection
hades db query "attention" --collection sync

# Set default via environment
export HADES_DEFAULT_COLLECTION=sync
hades db query "attention"  # now queries sync collection

# List available profiles
hades db stats --help  # shows: "Available: arxiv, default, sync"
```

## Test plan
- [x] `poetry run ruff check` passes
- [x] `poetry run python -m compileall core/` passes
- [x] `poetry run hades db stats --help` shows `--collection` option
- [x] `poetry run hades db query --help` shows `--collection` option

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--collection` (`-C`) option to database commands for multi-collection support
  * Support for default collection configuration via `HADES_DEFAULT_COLLECTION` environment variable

* **Changes**
  * Renamed `arxiv_id` parameter to `document_id` in database check and purge commands
  * Updated terminology throughout to refer to "documents" instead of "papers"

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->