### PR TITLE
Address CodeRabbit review comments from PR #80

### DIFF
--- a/core/cli/commands/status.py
+++ b/core/cli/commands/status.py
@@ -121,9 +121,11 @@ def _get_database_status() -> dict[str, Any]:
                     stats = _get_collection_stats(client, profile)
                     if stats:  # Only include if collection exists
                         collections_status[profile_name] = stats
-                except Exception:
-                    # Collection might not exist
-                    pass
+                except Exception as e:
+                    # Collection might not exist — log other errors for debugging
+                    import logging
+
+                    logging.debug("Could not get stats for %s: %s", profile_name, e)
 
             return {
                 "connected": True,


### PR DESCRIPTION
## Summary

Fixes three unresolved CodeRabbit review comments from PR #80 that were merged without addressing them.

- **AQL injection fix** (Major): `count_collection()` was interpolating user-provided collection names directly into AQL queries via f-string. Now uses `@@col` bind parameters.
- **Collection name validation**: Added `_validate_collection_name()` to all CRUD functions (`count`, `insert`, `get`, `update`) — rejects names that aren't alphanumeric/hyphens/underscores.
- **Narrowed exception handling**: `status.py` now logs exceptions instead of `except: pass`. `insert_documents()` auto-create only swallows "duplicate name" errors (ArangoDB 1207), re-raises others.

## Test plan

- [ ] Verify `db count <collection>` works with valid names
- [ ] Verify `db count "DROP TABLE"` returns VALIDATION_ERROR
- [ ] Verify `db insert` auto-create still works for new collections
- [ ] Verify `hades status` logs debug info for missing collections instead of silent swallow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection name validation now enforced consistently across database operations with clearer error messages.
  * Duplicate collection names during insertion are now handled gracefully.

* **Improvements**
  * Database status checks now log diagnostic information when errors occur, aiding troubleshooting instead of silently failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->