### PR TITLE
Add multi-database support: --database flag and db databases command

### DIFF
--- a/core/cli/agent_templates.py
+++ b/core/cli/agent_templates.py
@@ -32,6 +32,14 @@ HADES is a semantic graph RAG system backed by ArangoDB. It provides three compo
 
 The `hades` CLI outputs JSON to stdout; progress and logs go to stderr.
 
+## Global Options
+
+- `--database` / `--db` — Target a specific ArangoDB database for any command (overrides config/env)
+  ```bash
+  hades --database NL db collections      # list collections in NL database
+  hades --db arxiv_datastore db stats     # stats for arxiv_datastore
+  ```
+
 ## Important — Where to Search
 
 - `hades db query` — semantic search over ingested papers and synced abstracts
@@ -149,6 +157,10 @@ hades db graph neighbors --start "nodes/1" --graph my_graph
 # System overview
 hades status                               # version, service health, collection stats
 
+# Multi-database discovery
+hades db databases                         # list all accessible databases
+hades --database NL db collections         # collections in a specific database
+
 # Recent activity
 hades db recent                            # last 10 ingested papers
 hades db recent --limit 20 --collection sync
@@ -219,6 +231,7 @@ hades ingest --resume                      # continues from state file
 **Check what's in the knowledge base:**
 ```bash
 hades status                               # system overview
+hades db databases                         # list all databases
 hades db stats --all                       # all collections
 hades db list --limit 50                   # recent papers
 hades db collections                       # raw collection list
@@ -242,6 +255,8 @@ HADES_TOOL_SECTION = """\
 ### HADES
 
 The `hades` CLI provides semantic search over a knowledge base of academic papers backed by ArangoDB. It provides three composable tools: Extract (Docling), Embed (Jina v4), and Store (ArangoDB). All commands output JSON to stdout; progress goes to stderr.
+
+**Global Options:** `--database` / `--db` targets a specific ArangoDB database (e.g., `hades --database NL db query "text"`).
 
 **Important — Where to Search:** Use `hades db query --collection sync` to search 2.8M synced abstracts, `hades ingest` to download and store full papers, then `hades db query` to search over ingested full-text content.
 
@@ -329,6 +344,7 @@ hades db graph traverse --start "arxiv_metadata/2409_04701" --graph my_graph --d
 
 ```bash
 hades status                               # system overview
+hades db databases                         # list all accessible databases
 hades db recent                            # last 10 ingested papers
 hades db health                            # chunk/embedding consistency
 ```
@@ -374,6 +390,7 @@ hades db query "specific question"                               # deep search
 **Check what's in the knowledge base:**
 ```bash
 hades status
+hades db databases
 hades db stats --all
 hades db list --limit 50
 ```

--- a/core/cli/commands/status.py
+++ b/core/cli/commands/status.py
@@ -129,6 +129,7 @@ def _get_database_status() -> dict[str, Any]:
 
             return {
                 "connected": True,
+                "database": arango_config["database"],
                 "collections": collections_status,
             }
 

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -80,8 +80,14 @@ def main(
     version: bool = typer.Option(False, "--version", "-v", help="Show version and exit", is_eager=True),
     agent: str = typer.Option(None, "--agent", help="Install agent integration (claude or agent)", is_eager=True),
     gpu: int = typer.Option(None, "--gpu", "-g", help="GPU device index for embedding commands (e.g., 0, 1, 2)"),
+    database: str = typer.Option(
+        None, "--database", "--db", help="Target ArangoDB database name (overrides config/env)"
+    ),
 ) -> None:
     """HADES Knowledge Base CLI - AI model interface for semantic search over academic papers."""
+    if database:
+        os.environ["HADES_DATABASE"] = database
+
     if version:
         from importlib.metadata import version as get_version
 
@@ -838,6 +844,25 @@ def database_collections(
     from core.cli.commands.database import list_collections
 
     return list_collections(start_time, prefix=prefix, exclude_system=not show_system)
+
+
+@db_app.command("databases")
+@cli_command("database.databases", ErrorCode.DATABASE_ERROR)
+def database_databases(
+    start_time: float = typer.Option(0.0, hidden=True),
+) -> CLIResponse:
+    """List all accessible ArangoDB databases.
+
+    Shows all databases the configured user can access, and marks the
+    currently active database.
+
+    Examples:
+        hades db databases
+        hades --database NL db databases
+    """
+    from core.cli.commands.database import list_databases
+
+    return list_databases(start_time)
 
 
 @db_app.command("count")


### PR DESCRIPTION
## Summary

- Adds global `--database` / `--db` flag to target any ArangoDB database per-command (e.g., `hades --database NL db query "text"`)
- Adds `hades db databases` command to list all accessible databases and mark the current one
- Shows active database name in `hades status` output
- Documents new flag and command in agent templates

## Test plan

- [x] `hades db databases` lists all 7 databases with correct current marker
- [x] `--database NL` works with: `db collections`, `db stats --all`, `db list`, `db count`, `db get`, `db aql`, `db query` (full semantic search pipeline), `status`
- [x] `--db` shorthand works identically
- [x] Bogus database name returns clean 404 error
- [x] All existing commands without `--database` flag work unchanged (regression)
- [x] Tested across `NL`, `memrag_claude`, `memrag_shared` databases
- [x] Compile check and ruff lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Global `--database` / `--db` option to override the target ArangoDB database
  * New command to list all accessible ArangoDB databases with active database highlighted

* **Enhancements**
  * Status output now displays the current active database name

* **Documentation**
  * Updated command templates with database configuration examples and multi-database discovery references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->