### PR TITLE
Add NL named graph schema for knowledge base

### DIFF
--- a/core/database/nl_graph_schema.py
+++ b/core/database/nl_graph_schema.py
@@ -18,9 +18,11 @@ Edge collections (to be materialized):
     - Edges carry ``_from``, ``_to``, and optional metadata
 
 Named graphs compose edge collections into traversable units:
-    - nl_core: Universal axiom backbone (axiom_basis + validated_against)
-    - nl_inheritance: Axiom inheritance hierarchy
+    - nl_core: Universal axiom backbone (axiom_basis + validated_against + inherits_from)
     - nl_equations: Equation dependency network
+    - nl_hierarchy: Concept hierarchy (structural embodiments + lineage chains)
+    - nl_hecate: Build spec traceability
+    - nl_cross_paper: Cross-paper relationships
     - nl_concept_map: Full knowledge graph (all edges)
 
 Usage:


### PR DESCRIPTION
## Summary
- Adds `core/database/nl_graph_schema.py` — the complete graph schema for the NL knowledge base
- Maps 16 cross-reference patterns from 84 NL collections to **14 edge collections** and **6 named graphs**
- Provides `to_gharial_payload()` for direct ArangoDB `/_api/gharial` registration

## Edge Collections (14 unique)
| Edge Collection | Source Field | Description |
|---|---|---|
| `nl_axiom_basis_edges` | `axiom_basis` | Universal IS axiom compliance |
| `nl_validated_against_edges` | `validated_against` | IS_NOT anti-axiom validation |
| `nl_axiom_inherits_edges` | `inherits_from` | Paper axiom → NL root axiom inheritance |
| `nl_structural_embodiment_edges` | `structural_embodiments` | Axiom IS → definition embodiments |
| `nl_equation_depends_edges` | `depends_on` | Equation dependency DAG |
| `nl_definition_source_edges` | `source_equation` | Definition → source equation |
| `nl_signature_equation_edges` | `linked_equation` | Python signature → equation |
| `nl_reframing_link_edges` | `nl_reframing_link` | Concept → NL reframing |
| `nl_migration_edges` | `migrated_from` | nl_* → hope_* provenance |
| `nl_lineage_chain_edges` | `chain` | Ordered concept lineage chains |
| `nl_hecate_trace_edges` | `traced_to_*` | Hecate spec traceability |
| `nl_cross_paper_edges` | `from_node`/`to_node` | Cross-paper relationships |
| `nl_smell_compliance_edges` | `smell_compliance` | Code smell compliance |
| `nl_build_path_edges` | `counterpart` | Build path cross-refs |

## Named Graphs (6)
| Graph | Purpose | Edge Collections |
|---|---|---|
| `nl_core` | Axiom compliance backbone | 3 |
| `nl_equations` | Equation dependency network | 3 |
| `nl_hierarchy` | Concept hierarchy (embodiments + lineage) | 2 |
| `nl_hecate` | Build spec traceability | 1 |
| `nl_cross_paper` | Cross-paper relationships | 1 |
| `nl_concept_map` | Full knowledge graph (all edges) | 14 |

## Test plan
- [x] Module imports successfully
- [x] `to_gharial_payload()` generates valid ArangoDB API payloads
- [x] Ruff lint + format pass
- [x] `compileall` passes
- [ ] Edge materialization (blocked on this schema — next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive, exportable graph schema for the knowledge base, defining edge types and named graph groupings.
  * Provides programmatic accessors to enumerate and retrieve edge collections and named graphs.
  * Includes helpers to materialize graph definitions for deployment and to support varied graph analyses and cross-paper relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->