### PR TITLE
Fix: make lineage builder schema-driven

### DIFF
--- a/tests/core/database/test_nl_graph_materialize.py
+++ b/tests/core/database/test_nl_graph_materialize.py
@@ -1,0 +1,337 @@
+"""Tests for core.database.nl_graph_materialize — NL graph edge materialization."""
+
+from unittest.mock import MagicMock, patch
+
+from core.database.nl_graph_materialize import MaterializeStats, NLGraphMaterializer
+from core.database.nl_graph_schema import (
+    AXIOM_BASIS,
+    CROSS_PAPER,
+    LINEAGE_CHAIN,
+    EdgeCollectionDef,
+)
+
+
+class TestMaterializeStats:
+    def test_defaults(self):
+        stats = MaterializeStats()
+        assert stats.edges_created == 0
+        assert stats.edges_skipped == 0
+        assert stats.collections_scanned == 0
+        assert stats.collections_missing == 0
+        assert stats.errors == []
+        assert stats.duration_ms == 0.0
+
+    def test_to_dict(self):
+        stats = MaterializeStats(edges_created=10, edges_skipped=2, duration_ms=123.456)
+        d = stats.to_dict()
+        assert d["edges_created"] == 10
+        assert d["edges_skipped"] == 2
+        assert d["duration_ms"] == 123.5  # rounded
+
+    def test_errors_are_independent(self):
+        """Each Stats instance should have its own errors list."""
+        s1 = MaterializeStats()
+        s2 = MaterializeStats()
+        s1.errors.append("err1")
+        assert s2.errors == []
+
+
+class TestResolveRef:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.materializer = NLGraphMaterializer(self.client, database="test_db")
+
+    def test_full_id_passes_through(self):
+        assert self.materializer._resolve_ref("collection/key") == "collection/key"
+
+    def test_bare_key_returns_none(self):
+        assert self.materializer._resolve_ref("bare_key") is None
+
+    def test_empty_string_returns_none(self):
+        assert self.materializer._resolve_ref("") is None
+
+    def test_none_returns_none(self):
+        assert self.materializer._resolve_ref(None) is None
+
+    def test_non_string_returns_none(self):
+        assert self.materializer._resolve_ref(42) is None
+
+    def test_nested_slash(self):
+        assert self.materializer._resolve_ref("a/b/c") == "a/b/c"
+
+
+class TestBuildEdgesStandard:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.materializer = NLGraphMaterializer(self.client, database="test_db")
+
+    def test_single_ref_creates_edge(self):
+        """A doc with a string source_field should produce one edge."""
+        existing = {"src_coll", "tgt_coll"}
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref_field",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+        )
+        self.client.query.return_value = [{"_id": "src_coll/doc1", "_key": "doc1", "ref_field": "tgt_coll/target1"}]
+
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=True)
+        assert stats.edges_created == 1
+        assert stats.collections_scanned == 1
+
+    def test_array_ref_creates_multiple_edges(self):
+        """A doc with a list source_field should produce multiple edges."""
+        existing = {"src_coll", "tgt_coll"}
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="refs",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+            is_array=True,
+        )
+        self.client.query.return_value = [
+            {"_id": "src_coll/doc1", "_key": "doc1", "refs": ["tgt_coll/a", "tgt_coll/b", "tgt_coll/c"]}
+        ]
+
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=True)
+        assert stats.edges_created == 3
+
+    def test_missing_collection_skipped(self):
+        """Collections not in existing set should be skipped."""
+        existing = {"tgt_coll"}  # src_coll missing
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+        )
+
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=True)
+        assert stats.collections_missing == 1
+        assert stats.edges_created == 0
+
+    def test_bare_key_ref_skipped(self):
+        """References without collection prefix should be skipped."""
+        existing = {"src_coll", "tgt_coll"}
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+        )
+        self.client.query.return_value = [{"_id": "src_coll/doc1", "_key": "doc1", "ref": "bare_key_no_slash"}]
+
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=True)
+        assert stats.edges_created == 0
+        assert stats.edges_skipped == 1
+
+    def test_nonexistent_target_collection_skipped(self):
+        """Edges pointing to collections not in existing set should be skipped."""
+        existing = {"src_coll"}  # tgt_coll missing
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+        )
+        self.client.query.return_value = [{"_id": "src_coll/doc1", "_key": "doc1", "ref": "tgt_coll/target1"}]
+
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=True)
+        assert stats.edges_created == 0
+        assert stats.edges_skipped == 1
+
+    def test_edge_attributes_copied(self):
+        """edge_attributes from the source doc should be copied onto the edge."""
+        existing = {"src_coll", "tgt_coll", "test_edges"}
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+            edge_attributes=["name", "description"],
+        )
+        self.client.query.return_value = [
+            {
+                "_id": "src_coll/doc1",
+                "_key": "doc1",
+                "ref": "tgt_coll/target1",
+                "name": "test_name",
+                "description": "test_desc",
+            }
+        ]
+
+        # Mock _insert_edges to capture what was passed
+        inserted = []
+
+        def capture_insert(collection, edges):
+            inserted.extend(edges)
+            return {"created": len(edges), "errors": 0}
+
+        self.materializer._insert_edges = capture_insert
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=False)
+
+        assert stats.edges_created == 1
+        assert len(inserted) == 1
+        assert inserted[0]["name"] == "test_name"
+        assert inserted[0]["description"] == "test_desc"
+
+    def test_null_ref_field_skipped(self):
+        """Docs where the ref field is None should be skipped silently."""
+        existing = {"src_coll", "tgt_coll"}
+        edge_def = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["src_coll"],
+            to_collections=["tgt_coll"],
+            description="test",
+        )
+        self.client.query.return_value = [{"_id": "src_coll/doc1", "_key": "doc1", "ref": None}]
+
+        stats = self.materializer._build_edges_standard(edge_def, existing, dry_run=True)
+        assert stats.edges_created == 0
+        assert stats.edges_skipped == 0
+
+
+class TestBuildEdgesCrossPaper:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.materializer = NLGraphMaterializer(self.client, database="test_db")
+
+    def test_creates_edges_from_paired_fields(self):
+        existing = {"paper_edges", "src_coll", "tgt_coll"}
+        self.client.query.return_value = [
+            {
+                "_id": "paper_edges/edge1",
+                "_key": "edge1",
+                "from_node": "src_coll/a",
+                "to_node": "tgt_coll/b",
+                "name": "test relation",
+                "relationship": "extends",
+            }
+        ]
+
+        stats = self.materializer._build_edges_cross_paper(CROSS_PAPER, existing, dry_run=True)
+        assert stats.edges_created == 1
+        assert stats.collections_scanned == 1
+
+    def test_missing_paper_edges_collection(self):
+        existing = {"other_coll"}
+        stats = self.materializer._build_edges_cross_paper(CROSS_PAPER, existing, dry_run=True)
+        assert stats.collections_missing == 1
+        assert stats.edges_created == 0
+
+
+class TestBuildEdgesLineage:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.materializer = NLGraphMaterializer(self.client, database="test_db")
+
+    def test_chain_produces_sequential_and_membership_edges(self):
+        """A chain [A, B, C] should produce: A→B, B→C (sequential) + lineage→A, lineage→B, lineage→C (membership)."""
+        existing = {"atlas_lineage", "atlas_abstractions"}
+        lineage_def = EdgeCollectionDef(
+            name="nl_lineage_chain_edges",
+            source_field="chain",
+            from_collections=["atlas_lineage"],
+            to_collections=["atlas_abstractions"],
+            description="test",
+            is_array=True,
+            edge_attributes=["name", "type"],
+        )
+        self.client.query.return_value = [
+            {
+                "_id": "atlas_lineage/lineage1",
+                "_key": "lineage1",
+                "chain": [
+                    "atlas_abstractions/a",
+                    "atlas_abstractions/b",
+                    "atlas_abstractions/c",
+                ],
+                "name": "test lineage",
+                "type": "theoretical",
+            }
+        ]
+
+        stats = self.materializer._build_edges_lineage(lineage_def, existing, dry_run=True)
+        # 2 sequential (a→b, b→c) + 3 membership (lineage→a, lineage→b, lineage→c) = 5
+        assert stats.edges_created == 5
+
+    def test_short_chain_skipped(self):
+        """Chains with fewer than 2 items should be skipped."""
+        existing = {"atlas_lineage", "atlas_abstractions"}
+        lineage_def = EdgeCollectionDef(
+            name="nl_lineage_chain_edges",
+            source_field="chain",
+            from_collections=["atlas_lineage"],
+            to_collections=["atlas_abstractions"],
+            description="test",
+            is_array=True,
+        )
+        self.client.query.return_value = [{"_id": "atlas_lineage/l1", "_key": "l1", "chain": ["atlas_abstractions/a"]}]
+
+        stats = self.materializer._build_edges_lineage(lineage_def, existing, dry_run=True)
+        assert stats.edges_created == 0
+
+
+class TestMaterializeEdgeRouting:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.materializer = NLGraphMaterializer(self.client, database="test_db")
+
+    def test_cross_paper_routed_correctly(self):
+        with patch.object(self.materializer, "_build_edges_cross_paper") as mock:
+            mock.return_value = MaterializeStats()
+            self.materializer.materialize_edge(CROSS_PAPER, set())
+            mock.assert_called_once()
+
+    def test_lineage_routed_correctly(self):
+        with patch.object(self.materializer, "_build_edges_lineage") as mock:
+            mock.return_value = MaterializeStats()
+            self.materializer.materialize_edge(LINEAGE_CHAIN, set())
+            mock.assert_called_once()
+
+    def test_standard_routed_for_axiom_basis(self):
+        with patch.object(self.materializer, "_build_edges_standard") as mock:
+            mock.return_value = MaterializeStats()
+            self.materializer.materialize_edge(AXIOM_BASIS, set())
+            mock.assert_called_once()
+
+
+class TestMaterializeAll:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.materializer = NLGraphMaterializer(self.client, database="test_db")
+
+    def test_dry_run_flag_passed_through(self):
+        self.client.request.return_value = {"result": []}
+        with patch.object(self.materializer, "materialize_edge") as mock:
+            mock.return_value = MaterializeStats()
+            self.materializer.materialize_all(dry_run=True)
+            for call in mock.call_args_list:
+                assert call.kwargs.get("dry_run") is True or call.args[2] is True
+
+    def test_edge_filter_limits_processing(self):
+        self.client.request.return_value = {"result": []}
+        with patch.object(self.materializer, "materialize_edge") as mock:
+            mock.return_value = MaterializeStats()
+            self.materializer.materialize_all(edge_filter="nl_axiom_basis_edges")
+            # Only axiom_basis should be processed (1 definition)
+            assert mock.call_count == 1
+
+    def test_result_structure(self):
+        self.client.request.return_value = {"result": []}
+        with patch.object(self.materializer, "materialize_edge") as mock:
+            mock.return_value = MaterializeStats(edges_created=5)
+            result = self.materializer.materialize_all(dry_run=True)
+            assert "edge_collections" in result
+            assert "totals" in result
+            assert "dry_run" in result
+            assert "edge_collections_processed" in result
+            assert result["dry_run"] is True

--- a/tests/core/database/test_nl_graph_schema.py
+++ b/tests/core/database/test_nl_graph_schema.py
@@ -1,0 +1,219 @@
+"""Tests for core.database.nl_graph_schema — NL named graph schema definitions."""
+
+import pytest
+
+from core.database.nl_graph_schema import (
+    ALL_EDGE_COLLECTIONS,
+    ALL_NAMED_GRAPHS,
+    ALL_VERTEX_COLLECTIONS,
+    AXIOM_COLLECTIONS,
+    EQUATION_COLLECTIONS,
+    NL_GRAPH_SCHEMA,
+    PAPER_PREFIXES,
+    EdgeCollectionDef,
+    NamedGraphDef,
+    get_edge_definitions,
+    get_named_graphs,
+)
+
+
+class TestPaperPrefixes:
+    def test_known_papers_present(self):
+        assert "hope" in PAPER_PREFIXES
+        assert "atlas" in PAPER_PREFIXES
+        assert "titans" in PAPER_PREFIXES
+        assert "tnt" in PAPER_PREFIXES
+
+    def test_no_duplicates(self):
+        assert len(PAPER_PREFIXES) == len(set(PAPER_PREFIXES))
+
+
+class TestCollectionLists:
+    def test_vertex_collections_not_empty(self):
+        assert len(ALL_VERTEX_COLLECTIONS) > 50
+
+    def test_vertex_collections_sorted(self):
+        assert ALL_VERTEX_COLLECTIONS == sorted(ALL_VERTEX_COLLECTIONS)
+
+    def test_vertex_collections_no_duplicates(self):
+        assert len(ALL_VERTEX_COLLECTIONS) == len(set(ALL_VERTEX_COLLECTIONS))
+
+    def test_axiom_collections_include_nl(self):
+        assert "nl_axioms" in AXIOM_COLLECTIONS
+
+    def test_axiom_collections_include_papers(self):
+        for prefix in PAPER_PREFIXES:
+            assert f"{prefix}_axioms" in AXIOM_COLLECTIONS
+
+    def test_equation_collections_include_papers(self):
+        for prefix in PAPER_PREFIXES:
+            assert f"{prefix}_equations" in EQUATION_COLLECTIONS
+
+
+class TestEdgeCollectionDef:
+    def test_frozen(self):
+        edef = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["a"],
+            to_collections=["b"],
+            description="test",
+        )
+        with pytest.raises(AttributeError):
+            edef.name = "other"
+
+    def test_default_values(self):
+        edef = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["a"],
+            to_collections=["b"],
+            description="test",
+        )
+        assert edef.is_array is False
+        assert edef.edge_attributes == []
+        assert edef.extraction_note == "full_id"
+
+
+class TestNamedGraphDef:
+    def test_to_gharial_payload_structure(self):
+        edef = EdgeCollectionDef(
+            name="test_edges",
+            source_field="ref",
+            from_collections=["src_a", "src_b"],
+            to_collections=["tgt_a"],
+            description="test",
+        )
+        graph = NamedGraphDef(
+            name="test_graph",
+            edge_definitions=[edef],
+            description="test graph",
+        )
+        payload = graph.to_gharial_payload()
+        assert payload["name"] == "test_graph"
+        assert len(payload["edgeDefinitions"]) == 1
+        assert payload["edgeDefinitions"][0]["collection"] == "test_edges"
+        assert sorted(payload["edgeDefinitions"][0]["from"]) == ["src_a", "src_b"]
+        assert payload["edgeDefinitions"][0]["to"] == ["tgt_a"]
+
+    def test_shared_edge_collection_merges(self):
+        """Edge definitions sharing a collection name should merge from/to sets."""
+        edef1 = EdgeCollectionDef(
+            name="shared_edges",
+            source_field="field_a",
+            from_collections=["src_a"],
+            to_collections=["tgt_a"],
+            description="first",
+        )
+        edef2 = EdgeCollectionDef(
+            name="shared_edges",
+            source_field="field_b",
+            from_collections=["src_b"],
+            to_collections=["tgt_b"],
+            description="second",
+        )
+        graph = NamedGraphDef(
+            name="merged_graph",
+            edge_definitions=[edef1, edef2],
+            description="test",
+        )
+        payload = graph.to_gharial_payload()
+        assert len(payload["edgeDefinitions"]) == 1
+        edge_def = payload["edgeDefinitions"][0]
+        assert edge_def["collection"] == "shared_edges"
+        assert "src_a" in edge_def["from"]
+        assert "src_b" in edge_def["from"]
+        assert "tgt_a" in edge_def["to"]
+        assert "tgt_b" in edge_def["to"]
+
+
+class TestNLGraphSchema:
+    def test_singleton_has_edge_collections(self):
+        assert len(NL_GRAPH_SCHEMA.edge_collections) == 16
+
+    def test_singleton_has_named_graphs(self):
+        assert len(NL_GRAPH_SCHEMA.named_graphs) == 6
+
+    def test_unique_edge_collection_names(self):
+        names = NL_GRAPH_SCHEMA.all_edge_collection_names()
+        assert len(names) == 14  # 16 defs but some share names (hecate)
+
+    def test_named_graph_names(self):
+        names = NL_GRAPH_SCHEMA.all_named_graph_names()
+        assert "nl_core" in names
+        assert "nl_equations" in names
+        assert "nl_hierarchy" in names
+        assert "nl_hecate" in names
+        assert "nl_cross_paper" in names
+        assert "nl_concept_map" in names
+
+    def test_get_edge_collection_found(self):
+        ec = NL_GRAPH_SCHEMA.get_edge_collection("nl_axiom_basis_edges")
+        assert ec.source_field == "axiom_basis"
+
+    def test_get_edge_collection_not_found(self):
+        with pytest.raises(KeyError, match="nonexistent"):
+            NL_GRAPH_SCHEMA.get_edge_collection("nonexistent")
+
+    def test_get_named_graph_found(self):
+        ng = NL_GRAPH_SCHEMA.get_named_graph("nl_core")
+        assert len(ng.edge_definitions) == 3
+
+    def test_get_named_graph_not_found(self):
+        with pytest.raises(KeyError, match="nonexistent"):
+            NL_GRAPH_SCHEMA.get_named_graph("nonexistent")
+
+    def test_concept_map_includes_all_edges(self):
+        concept_map = NL_GRAPH_SCHEMA.get_named_graph("nl_concept_map")
+        assert len(concept_map.edge_definitions) == len(ALL_EDGE_COLLECTIONS)
+
+    def test_all_edge_defs_have_from_and_to(self):
+        for edef in NL_GRAPH_SCHEMA.edge_collections:
+            assert len(edef.from_collections) > 0, f"{edef.name} has no from_collections"
+            assert len(edef.to_collections) > 0, f"{edef.name} has no to_collections"
+
+    def test_all_edge_defs_have_description(self):
+        for edef in NL_GRAPH_SCHEMA.edge_collections:
+            assert len(edef.description) > 10, f"{edef.name} has short description"
+
+
+class TestHelperFunctions:
+    def test_get_edge_definitions(self):
+        defs = get_edge_definitions()
+        assert len(defs) == len(ALL_EDGE_COLLECTIONS)
+        assert defs is not NL_GRAPH_SCHEMA.edge_collections  # returns copy
+
+    def test_get_named_graphs(self):
+        graphs = get_named_graphs()
+        assert len(graphs) == len(ALL_NAMED_GRAPHS)
+        assert graphs is not NL_GRAPH_SCHEMA.named_graphs  # returns copy
+
+
+class TestGharialPayloads:
+    def test_all_named_graphs_produce_valid_payloads(self):
+        for graph in NL_GRAPH_SCHEMA.named_graphs:
+            payload = graph.to_gharial_payload()
+            assert "name" in payload
+            assert "edgeDefinitions" in payload
+            assert len(payload["edgeDefinitions"]) > 0
+            for edef in payload["edgeDefinitions"]:
+                assert "collection" in edef
+                assert "from" in edef
+                assert "to" in edef
+                assert isinstance(edef["from"], list)
+                assert isinstance(edef["to"], list)
+                assert len(edef["from"]) > 0
+                assert len(edef["to"]) > 0
+
+    def test_hecate_graph_merges_three_traced_fields(self):
+        hecate = NL_GRAPH_SCHEMA.get_named_graph("nl_hecate")
+        payload = hecate.to_gharial_payload()
+        assert len(payload["edgeDefinitions"]) == 1  # all share nl_hecate_trace_edges
+        edef = payload["edgeDefinitions"][0]
+        assert edef["collection"] == "nl_hecate_trace_edges"
+        assert "hecate_specs" in edef["from"]
+
+    def test_edge_collection_names_follow_convention(self):
+        for name in NL_GRAPH_SCHEMA.all_edge_collection_names():
+            assert name.startswith("nl_"), f"{name} doesn't start with nl_"
+            assert name.endswith("_edges"), f"{name} doesn't end with _edges"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `"chain"` with `edge_def.source_field` in `_build_edges_lineage`
- Copies `edge_def.edge_attributes` onto lineage edges (was missing)
- Addresses missed CodeRabbit comment from PR #113

## Test plan
- [x] Ruff lint + format pass
- [x] Module imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Graph materialization now uses a configurable source field and preserves additional edge attributes and accurate source metadata during edge generation.
  * Edge insertion behavior adjusted to avoid unintentionally truncating shared edge collections.

* **Tests**
  * Added extensive unit tests covering edge building (standard, cross-paper, lineage), routing, materialization runs, schema integrity, and related helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->