### PR TITLE
Add Persephone Phase 4: structured handoff system

### DIFF
--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -1801,6 +1801,64 @@ def task_unblock_cmd(
     return task_transition(key, "in_progress", start_time)
 
 
+# --- Handoff commands (Phase 4: structured handoffs) ---
+
+
+@task_app.command("handoff")
+@cli_command("task.handoff", ErrorCode.TASK_ERROR)
+def task_handoff_cmd(
+    key: str = typer.Argument(..., help="Task key", metavar="KEY"),
+    done: list[str] = typer.Option(None, "--done", help="What was completed (repeatable)"),
+    remaining: list[str] = typer.Option(None, "--remaining", help="What still needs doing (repeatable)"),
+    decision: list[str] = typer.Option(None, "--decision", help="Key decision made (repeatable)"),
+    uncertain: list[str] = typer.Option(None, "--uncertain", help="Open question / unknown (repeatable)"),
+    note: str = typer.Option(None, "--note", "-n", help="Free-form note"),
+    start_time: float = typer.Option(0.0, hidden=True),
+) -> CLIResponse:
+    """Create a structured handoff for a task.
+
+    Captures what was done, what remains, key decisions, and uncertainties.
+    The next session picks up this context automatically via 'task usage'.
+    Multiple --done, --remaining, --decision, --uncertain flags are allowed.
+
+    Examples:
+        hades task handoff task_abc123 --done "Implemented state machine" --remaining "Add tests"
+        hades task handoff task_abc123 --decision "Used graph edges over foreign keys" --note "All tests pass"
+    """
+    from core.cli.commands.persephone import task_handoff
+
+    return task_handoff(
+        key,
+        start_time,
+        done=done or None,
+        remaining=remaining or None,
+        decisions=decision or None,
+        uncertain=uncertain or None,
+        note=note,
+    )
+
+
+@task_app.command("handoff-show")
+@cli_command("task.handoff-show", ErrorCode.TASK_ERROR)
+def task_handoff_show_cmd(
+    key: str = typer.Argument(..., help="Task key", metavar="KEY"),
+    limit: int = typer.Option(10, "--limit", "-n", help="Maximum handoffs to show"),
+    start_time: float = typer.Option(0.0, hidden=True),
+) -> CLIResponse:
+    """Show handoff history for a task.
+
+    Lists handoffs in reverse chronological order. Shows the latest
+    handoff prominently for quick context pickup.
+
+    Examples:
+        hades task handoff-show task_abc123
+        hades task handoff-show task_abc123 --limit 5
+    """
+    from core.cli.commands.persephone import task_handoff_show
+
+    return task_handoff_show(key, start_time, limit=limit)
+
+
 @task_app.command("dep")
 @cli_command("task.dep", ErrorCode.TASK_ERROR)
 def task_dep_cmd(

--- a/core/persephone/handoffs.py
+++ b/core/persephone/handoffs.py
@@ -1,0 +1,224 @@
+"""Persephone handoff management.
+
+Structured handoff documents capture context between agent sessions:
+what was done, what remains, key decisions, and uncertainties. Stored
+as first-class ArangoDB graph nodes linked to sessions and tasks via
+edges in persephone_edges.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import subprocess
+from typing import Any
+
+from core.persephone.collections import PERSEPHONE_COLLECTIONS, PersephoneCollections
+from core.persephone.sessions import _create_edge, _utcnow, get_or_create_session
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_handoff_key() -> str:
+    """Generate a handoff key: hnd_XXXXXX (6-char random hex)."""
+    return f"hnd_{secrets.token_hex(3)}"
+
+
+def _capture_git_state() -> dict[str, Any]:
+    """Capture current git state (best-effort).
+
+    Returns dict with git_branch, git_sha, git_dirty_files.
+    All values are None if git is unavailable.
+    """
+    cwd = os.environ.get("HADES_PROJECT_ROOT", ".")
+    result: dict[str, Any] = {
+        "git_branch": None,
+        "git_sha": None,
+        "git_dirty_files": None,
+    }
+
+    try:
+        sha_out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        )
+        if sha_out.returncode == 0:
+            result["git_sha"] = sha_out.stdout.strip()
+
+        branch_out = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        )
+        if branch_out.returncode == 0:
+            result["git_branch"] = branch_out.stdout.strip() or None
+
+        status_out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        )
+        if status_out.returncode == 0:
+            lines = [ln for ln in status_out.stdout.strip().split("\n") if ln]
+            result["git_dirty_files"] = len(lines)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+
+    return result
+
+
+def create_handoff(
+    client: Any,
+    db_name: str,
+    task_key: str,
+    *,
+    done: list[str] | None = None,
+    remaining: list[str] | None = None,
+    decisions: list[str] | None = None,
+    uncertain: list[str] | None = None,
+    note: str | None = None,
+    session: dict[str, Any] | None = None,
+    collections: PersephoneCollections | None = None,
+) -> dict[str, Any]:
+    """Create a handoff document linked to a task and session.
+
+    Args:
+        client: ArangoHttp2Client instance
+        db_name: Target database name
+        task_key: Task this handoff is for
+        done: What was completed
+        remaining: What still needs doing
+        decisions: Key decisions made (and rationale)
+        uncertain: Open questions / unknowns
+        note: Free-form note
+        session: Session dict (auto-detected if None)
+        collections: Collection names override
+
+    Returns:
+        Created handoff document dict
+
+    Raises:
+        ValueError: If no content fields are provided
+    """
+    if not any([done, remaining, decisions, uncertain, note]):
+        raise ValueError("At least one content field required (done, remaining, decisions, uncertain, or note)")
+
+    cols = collections or PERSEPHONE_COLLECTIONS
+
+    # Auto-detect session
+    if session is None:
+        session = get_or_create_session(client, db_name, collections=cols)
+    session_key = session["_key"]
+
+    # Capture git state
+    git = _capture_git_state()
+
+    key = _generate_handoff_key()
+    now = _utcnow()
+
+    doc: dict[str, Any] = {
+        "_key": key,
+        "task_key": task_key,
+        "session_key": session_key,
+        "done": done or [],
+        "remaining": remaining or [],
+        "decisions": decisions or [],
+        "uncertain": uncertain or [],
+        "note": note,
+        "git_branch": git["git_branch"],
+        "git_sha": git["git_sha"],
+        "git_dirty_files": git["git_dirty_files"],
+        "created_at": now,
+    }
+
+    resp = client.request(
+        "POST",
+        f"/_db/{db_name}/_api/document/{cols.handoffs}",
+        json=doc,
+    )
+    doc["_id"] = resp.get("_id", f"{cols.handoffs}/{key}")
+    doc["_rev"] = resp.get("_rev")
+
+    # Create edges: session → handoff, handoff → task
+    _create_edge(
+        client, db_name,
+        _from=f"{cols.sessions}/{session_key}",
+        _to=f"{cols.handoffs}/{key}",
+        edge_type="authored_handoff",
+        collections=cols,
+    )
+    _create_edge(
+        client, db_name,
+        _from=f"{cols.handoffs}/{key}",
+        _to=f"{cols.tasks}/{task_key}",
+        edge_type="handoff_for",
+        collections=cols,
+    )
+
+    logger.info("Created handoff %s for task %s (session %s)", key, task_key, session_key)
+    return doc
+
+
+def get_latest_handoff(
+    client: Any,
+    db_name: str,
+    task_key: str,
+    *,
+    collections: PersephoneCollections | None = None,
+) -> dict[str, Any] | None:
+    """Get the most recent handoff for a task.
+
+    Uses edge traversal: find handoff_for edges pointing to the task,
+    sort by created_at descending, return the newest.
+    """
+    cols = collections or PERSEPHONE_COLLECTIONS
+
+    results = client.query(
+        """
+        FOR e IN @@edges
+            FILTER e._to == @task_id
+            FILTER e.type == "handoff_for"
+            FOR h IN @@handoffs
+                FILTER h._id == e._from
+                SORT h.created_at DESC
+                LIMIT 1
+                RETURN h
+        """,
+        bind_vars={
+            "@edges": cols.edges,
+            "@handoffs": cols.handoffs,
+            "task_id": f"{cols.tasks}/{task_key}",
+        },
+    )
+
+    return results[0] if results else None
+
+
+def list_handoffs(
+    client: Any,
+    db_name: str,
+    task_key: str,
+    *,
+    limit: int = 10,
+    collections: PersephoneCollections | None = None,
+) -> list[dict[str, Any]]:
+    """List handoffs for a task, newest first."""
+    cols = collections or PERSEPHONE_COLLECTIONS
+
+    return client.query(
+        """
+        FOR e IN @@edges
+            FILTER e._to == @task_id
+            FILTER e.type == "handoff_for"
+            FOR h IN @@handoffs
+                FILTER h._id == e._from
+                SORT h.created_at DESC
+                LIMIT @limit
+                RETURN h
+        """,
+        bind_vars={
+            "@edges": cols.edges,
+            "@handoffs": cols.handoffs,
+            "task_id": f"{cols.tasks}/{task_key}",
+            "limit": limit,
+        },
+    )

--- a/core/persephone/sessions.py
+++ b/core/persephone/sessions.py
@@ -573,6 +573,16 @@ def build_usage_briefing(
         bind_vars={"@tasks": cols.tasks},
     )
 
+    # For each in-progress task, fetch latest handoff for context
+    handoffs: dict[str, Any] = {}
+    if in_progress:
+        from core.persephone.handoffs import get_latest_handoff
+
+        for task in in_progress:
+            handoff = get_latest_handoff(client, db_name, task["_key"], collections=cols)
+            if handoff:
+                handoffs[task["_key"]] = handoff
+
     return {
         "session": {
             "key": session["_key"],
@@ -581,6 +591,7 @@ def build_usage_briefing(
             "started_at": session.get("started_at"),
         },
         "in_progress": in_progress,
+        "handoffs": handoffs,
         "reviewable": reviewable,
         "ready": ready,
     }

--- a/tests/core/persephone/test_handoffs.py
+++ b/tests/core/persephone/test_handoffs.py
@@ -1,0 +1,306 @@
+"""Tests for core.persephone.handoffs — structured handoff management."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.persephone.handoffs import (
+    _capture_git_state,
+    _generate_handoff_key,
+    create_handoff,
+    get_latest_handoff,
+    list_handoffs,
+)
+from core.persephone.sessions import build_usage_briefing
+
+
+class TestGenerateHandoffKey:
+    def test_format(self):
+        key = _generate_handoff_key()
+        assert key.startswith("hnd_")
+        assert len(key) == 10  # hnd_ + 6 hex chars
+
+    def test_unique(self):
+        keys = {_generate_handoff_key() for _ in range(100)}
+        assert len(keys) == 100
+
+
+class TestCaptureGitState:
+    def test_captures_all_fields(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="abc123def456\n"),  # rev-parse HEAD
+                MagicMock(returncode=0, stdout="feat/phase4\n"),   # branch --show-current
+                MagicMock(returncode=0, stdout="M file1.py\nA file2.py\n"),  # status --porcelain
+            ]
+            result = _capture_git_state()
+
+        assert result["git_sha"] == "abc123def456"
+        assert result["git_branch"] == "feat/phase4"
+        assert result["git_dirty_files"] == 2
+
+    def test_handles_git_unavailable(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = _capture_git_state()
+
+        assert result["git_sha"] is None
+        assert result["git_branch"] is None
+        assert result["git_dirty_files"] is None
+
+    def test_handles_timeout(self):
+        import subprocess
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 5)):
+            result = _capture_git_state()
+
+        assert result["git_sha"] is None
+
+    def test_handles_detached_head(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="abc123\n"),  # rev-parse HEAD
+                MagicMock(returncode=0, stdout="\n"),          # branch --show-current (empty in detached HEAD)
+                MagicMock(returncode=0, stdout=""),            # status --porcelain (clean)
+            ]
+            result = _capture_git_state()
+
+        assert result["git_sha"] == "abc123"
+        assert result["git_branch"] is None  # empty string → None
+        assert result["git_dirty_files"] == 0
+
+    def test_clean_repo(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="abc123\n"),
+                MagicMock(returncode=0, stdout="main\n"),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            result = _capture_git_state()
+
+        assert result["git_dirty_files"] == 0
+
+
+class TestCreateHandoff:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.client.request.return_value = {"_id": "persephone_handoffs/hnd_abc123", "_rev": "1"}
+        self.session = {
+            "_key": "ses_abc123",
+            "_id": "persephone_sessions/ses_abc123",
+            "agent_type": "claude_code",
+        }
+
+    @patch("core.persephone.handoffs._capture_git_state")
+    def test_creates_handoff_with_all_fields(self, mock_git):
+        mock_git.return_value = {"git_branch": "main", "git_sha": "abc", "git_dirty_files": 0}
+
+        doc = create_handoff(
+            self.client,
+            "bident",
+            "task_xyz",
+            done=["Implemented feature"],
+            remaining=["Add tests"],
+            decisions=["Used graph edges"],
+            uncertain=["Performance impact?"],
+            note="Looking good",
+            session=self.session,
+        )
+
+        assert doc["task_key"] == "task_xyz"
+        assert doc["session_key"] == "ses_abc123"
+        assert doc["done"] == ["Implemented feature"]
+        assert doc["remaining"] == ["Add tests"]
+        assert doc["decisions"] == ["Used graph edges"]
+        assert doc["uncertain"] == ["Performance impact?"]
+        assert doc["note"] == "Looking good"
+        assert doc["git_branch"] == "main"
+        assert doc["git_sha"] == "abc"
+        assert doc["git_dirty_files"] == 0
+        assert "created_at" in doc
+
+    @patch("core.persephone.handoffs._capture_git_state")
+    def test_creates_edges(self, mock_git):
+        mock_git.return_value = {"git_branch": None, "git_sha": None, "git_dirty_files": None}
+
+        create_handoff(
+            self.client,
+            "bident",
+            "task_xyz",
+            done=["Something"],
+            session=self.session,
+        )
+
+        # Should create: 1 handoff doc + 2 edges = 3 POST requests
+        post_calls = [c for c in self.client.request.call_args_list if c[0][0] == "POST"]
+        assert len(post_calls) == 3
+
+        # Check edge types from the JSON payloads
+        edge_types = [c[1]["json"]["type"] for c in post_calls if "type" in c[1].get("json", {})]
+        assert "authored_handoff" in edge_types
+        assert "handoff_for" in edge_types
+
+    @patch("core.persephone.handoffs._capture_git_state")
+    def test_auto_detects_session(self, mock_git):
+        mock_git.return_value = {"git_branch": None, "git_sha": None, "git_dirty_files": None}
+
+        with patch("core.persephone.handoffs.get_or_create_session") as mock_session:
+            mock_session.return_value = self.session
+            create_handoff(
+                self.client,
+                "bident",
+                "task_xyz",
+                done=["Something"],
+                # session=None → auto-detect
+            )
+            mock_session.assert_called_once()
+
+    def test_raises_if_no_content(self):
+        with pytest.raises(ValueError, match="At least one content field required"):
+            create_handoff(
+                self.client,
+                "bident",
+                "task_xyz",
+                session=self.session,
+            )
+
+    @patch("core.persephone.handoffs._capture_git_state")
+    def test_defaults_empty_lists(self, mock_git):
+        mock_git.return_value = {"git_branch": None, "git_sha": None, "git_dirty_files": None}
+
+        doc = create_handoff(
+            self.client,
+            "bident",
+            "task_xyz",
+            note="Just a note",
+            session=self.session,
+        )
+
+        assert doc["done"] == []
+        assert doc["remaining"] == []
+        assert doc["decisions"] == []
+        assert doc["uncertain"] == []
+        assert doc["note"] == "Just a note"
+
+
+class TestGetLatestHandoff:
+    def test_returns_newest(self):
+        client = MagicMock()
+        handoff = {
+            "_key": "hnd_latest",
+            "task_key": "task_xyz",
+            "done": ["Latest work"],
+            "created_at": "2026-02-17T12:00:00+00:00",
+        }
+        client.query.return_value = [handoff]
+
+        result = get_latest_handoff(client, "bident", "task_xyz")
+        assert result["_key"] == "hnd_latest"
+
+        # Verify AQL uses correct task ID
+        bind_vars = client.query.call_args[1]["bind_vars"]
+        assert bind_vars["task_id"] == "persephone_tasks/task_xyz"
+
+    def test_returns_none_when_empty(self):
+        client = MagicMock()
+        client.query.return_value = []
+
+        result = get_latest_handoff(client, "bident", "task_xyz")
+        assert result is None
+
+
+class TestListHandoffs:
+    def test_returns_sorted_list(self):
+        client = MagicMock()
+        handoffs = [
+            {"_key": "hnd_2", "created_at": "2026-02-17T12:00:00+00:00"},
+            {"_key": "hnd_1", "created_at": "2026-02-17T11:00:00+00:00"},
+        ]
+        client.query.return_value = handoffs
+
+        result = list_handoffs(client, "bident", "task_xyz")
+        assert len(result) == 2
+        assert result[0]["_key"] == "hnd_2"
+
+    def test_respects_limit(self):
+        client = MagicMock()
+        client.query.return_value = []
+
+        list_handoffs(client, "bident", "task_xyz", limit=5)
+
+        bind_vars = client.query.call_args[1]["bind_vars"]
+        assert bind_vars["limit"] == 5
+
+    def test_returns_empty_list(self):
+        client = MagicMock()
+        client.query.return_value = []
+
+        result = list_handoffs(client, "bident", "task_xyz")
+        assert result == []
+
+
+class TestBriefingWithHandoffs:
+    def setup_method(self):
+        self.client = MagicMock()
+        self.session = {
+            "_key": "ses_abc123",
+            "agent_type": "claude_code",
+            "branch": "main",
+            "started_at": "2026-02-17T00:00:00+00:00",
+        }
+
+    def test_includes_handoffs_for_in_progress_tasks(self):
+        in_progress_task = {
+            "_key": "task_2",
+            "_id": "persephone_tasks/task_2",
+            "title": "Working on it",
+            "status": "in_progress",
+        }
+        handoff = {
+            "_key": "hnd_abc",
+            "task_key": "task_2",
+            "done": ["Setup complete"],
+            "remaining": ["Write tests"],
+        }
+
+        self.client.query.side_effect = [
+            [in_progress_task],  # in_progress query
+            [],                  # reviewable query
+            [],                  # ready query
+        ]
+
+        with patch("core.persephone.handoffs.get_latest_handoff", return_value=handoff):
+            briefing = build_usage_briefing(self.client, "bident", self.session)
+
+        assert "handoffs" in briefing
+        assert "task_2" in briefing["handoffs"]
+        assert briefing["handoffs"]["task_2"]["done"] == ["Setup complete"]
+
+    def test_no_handoffs_when_no_in_progress(self):
+        self.client.query.side_effect = [
+            [],  # in_progress
+            [],  # reviewable
+            [],  # ready
+        ]
+
+        briefing = build_usage_briefing(self.client, "bident", self.session)
+        assert "handoffs" in briefing
+        assert briefing["handoffs"] == {}
+
+    def test_skips_tasks_without_handoffs(self):
+        task = {
+            "_key": "task_3",
+            "_id": "persephone_tasks/task_3",
+            "title": "No handoff yet",
+            "status": "in_progress",
+        }
+
+        self.client.query.side_effect = [
+            [task],  # in_progress
+            [],      # reviewable
+            [],      # ready
+        ]
+
+        with patch("core.persephone.handoffs.get_latest_handoff", return_value=None):
+            briefing = build_usage_briefing(self.client, "bident", self.session)
+
+        assert briefing["handoffs"] == {}

--- a/tests/core/persephone/test_sessions.py
+++ b/tests/core/persephone/test_sessions.py
@@ -296,8 +296,10 @@ class TestBuildUsageBriefing:
             [in_progress_task],  # in_progress
             [],  # reviewable
             [],  # ready
+            [],  # handoff lookup for task_2
         ]
 
         briefing = build_usage_briefing(self.client, "bident", self.session)
         assert len(briefing["in_progress"]) == 1
         assert briefing["in_progress"][0]["_key"] == "task_2"
+        assert "handoffs" in briefing


### PR DESCRIPTION
## Summary
- Adds graph-linked handoff documents that capture agent session context (done/remaining/decisions/uncertainties) with automatic git state snapshots
- Handoffs are first-class ArangoDB vertices connected via `authored_handoff` and `handoff_for` edges, enabling traversal in Phase 6
- `build_usage_briefing()` now includes latest handoffs for in-progress tasks, so new sessions automatically receive prior context via `task usage`
- CLI commands: `hades task handoff <key>` (create) and `hades task handoff-show <key>` (view history)

## Test plan
- [x] 20 new unit tests in `test_handoffs.py` (key gen, git capture, CRUD, edges, briefing integration)
- [x] All 78 Persephone tests pass (`pytest tests/core/persephone/`)
- [x] Ruff lint clean
- [x] `compileall core/` passes
- [ ] Functional test against bident database

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added handoff functionality to capture task progress, including done items, remaining tasks, decisions, uncertainties, and notes.
  * Introduced CLI commands to create handoffs and view handoff history for tasks.
  * Handoffs are now automatically included in task briefings for in-progress work.

* **Tests**
  * Added comprehensive test coverage for handoff creation, retrieval, listing, and briefing integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->