### PR TITLE
fix(ingest): eliminate overwrite=true truncation and HTTP 501 on large repos

### DIFF
--- a/core/cli/commands/codebase.py
+++ b/core/cli/commands/codebase.py
@@ -213,36 +213,42 @@ def _analyze_rust_crate(
             has_edges = cols.edges in existing_cols
 
             if has_symbols:
-                # Batch path lists to avoid AQL cursor pagination.
-                # ArangoDB on Unix domain sockets returns HTTP 501 for
-                # Transfer-Encoding: chunked, which cursor PUT triggers
-                # when result sets exceed batchSize.
+                # Perform stale cleanup entirely server-side to avoid
+                # materializing symbol lists in Python (which can trigger
+                # HTTP 501 cursor pagination on ArangoDB UDS).  Batched
+                # by paths to keep bind-var payloads small.
                 _BATCH = 30
-                stale_keys: list[str] = []
+
                 for i in range(0, len(all_attempted_paths), _BATCH):
                     batch = all_attempted_paths[i : i + _BATCH]
-                    stale_keys.extend(
+                    file_ids = [f"{cols.files}/{file_key(p)}" for p in batch]
+
+                    if has_edges:
+                        # Remove edges referencing stale symbols or file
+                        # nodes — symbol lookup stays inside AQL.
                         client.query(
-                            "FOR s IN @@symbols FILTER s.file_path IN @paths RETURN s._key",
-                            bind_vars={"@symbols": cols.symbols, "paths": batch},
+                            """
+                            LET sym_ids = (
+                                FOR s IN @@symbols
+                                    FILTER s.file_path IN @paths
+                                    RETURN s._id
+                            )
+                            LET all_ids = APPEND(sym_ids, @file_ids)
+                            FOR e IN @@edges
+                                FILTER e.type IN @types
+                                    AND (e._from IN all_ids OR e._to IN all_ids)
+                                REMOVE e IN @@edges
+                            """,
+                            bind_vars={
+                                "@symbols": cols.symbols,
+                                "@edges": cols.edges,
+                                "paths": batch,
+                                "file_ids": file_ids,
+                                "types": rust_edge_types,
+                            },
                         )
-                    )
 
-                stale_symbol_ids = [f"{cols.symbols}/{k}" for k in stale_keys]
-                file_ids = [f"{cols.files}/{file_key(p)}" for p in all_attempted_paths]
-                stale_ids = file_ids + stale_symbol_ids
-
-                if has_edges and stale_ids:
-                    for i in range(0, len(stale_ids), _BATCH):
-                        batch_ids = stale_ids[i : i + _BATCH]
-                        client.query(
-                            "FOR e IN @@edges FILTER e.type IN @types AND (e._from IN @ids OR e._to IN @ids) REMOVE e IN @@edges",
-                            bind_vars={"@edges": cols.edges, "types": rust_edge_types, "ids": batch_ids},
-                        )
-
-                # Now remove old symbols (also batched)
-                for i in range(0, len(all_attempted_paths), _BATCH):
-                    batch = all_attempted_paths[i : i + _BATCH]
+                    # Remove the symbols themselves
                     client.query(
                         "FOR s IN @@symbols FILTER s.file_path IN @paths REMOVE s IN @@symbols",
                         bind_vars={"@symbols": cols.symbols, "paths": batch},

--- a/core/cli/commands/codebase.py
+++ b/core/cli/commands/codebase.py
@@ -157,7 +157,11 @@ def _analyze_rust_crate(
             # Track all files we attempt (for stale cleanup even on failure)
             all_attempted_paths: list[str] = []
 
-            for rs_file in rs_files:
+            for i, rs_file in enumerate(rs_files):
+                print(
+                    f"  [{i + 1}/{len(rs_files)}] {rs_file}",
+                    file=sys.stderr,
+                )
                 abs_path = Path(repo_root) / rs_file
                 crate_rel = str(abs_path.relative_to(crate_root))
                 all_attempted_paths.append(rs_file)
@@ -209,26 +213,40 @@ def _analyze_rust_crate(
             has_edges = cols.edges in existing_cols
 
             if has_symbols:
-                # Get old symbol keys before deletion
-                stale_keys = client.query(
-                    "FOR s IN @@symbols FILTER s.file_path IN @paths RETURN s._key",
-                    bind_vars={"@symbols": cols.symbols, "paths": all_attempted_paths},
-                )
+                # Batch path lists to avoid AQL cursor pagination.
+                # ArangoDB on Unix domain sockets returns HTTP 501 for
+                # Transfer-Encoding: chunked, which cursor PUT triggers
+                # when result sets exceed batchSize.
+                _BATCH = 30
+                stale_keys: list[str] = []
+                for i in range(0, len(all_attempted_paths), _BATCH):
+                    batch = all_attempted_paths[i : i + _BATCH]
+                    stale_keys.extend(
+                        client.query(
+                            "FOR s IN @@symbols FILTER s.file_path IN @paths RETURN s._key",
+                            bind_vars={"@symbols": cols.symbols, "paths": batch},
+                        )
+                    )
+
                 stale_symbol_ids = [f"{cols.symbols}/{k}" for k in stale_keys]
                 file_ids = [f"{cols.files}/{file_key(p)}" for p in all_attempted_paths]
                 stale_ids = file_ids + stale_symbol_ids
 
                 if has_edges and stale_ids:
-                    client.query(
-                        "FOR e IN @@edges FILTER e.type IN @types AND (e._from IN @ids OR e._to IN @ids) REMOVE e IN @@edges",
-                        bind_vars={"@edges": cols.edges, "types": rust_edge_types, "ids": stale_ids},
-                    )
+                    for i in range(0, len(stale_ids), _BATCH):
+                        batch_ids = stale_ids[i : i + _BATCH]
+                        client.query(
+                            "FOR e IN @@edges FILTER e.type IN @types AND (e._from IN @ids OR e._to IN @ids) REMOVE e IN @@edges",
+                            bind_vars={"@edges": cols.edges, "types": rust_edge_types, "ids": batch_ids},
+                        )
 
-                # Now remove old symbols
-                client.query(
-                    "FOR s IN @@symbols FILTER s.file_path IN @paths REMOVE s IN @@symbols",
-                    bind_vars={"@symbols": cols.symbols, "paths": all_attempted_paths},
-                )
+                # Now remove old symbols (also batched)
+                for i in range(0, len(all_attempted_paths), _BATCH):
+                    batch = all_attempted_paths[i : i + _BATCH]
+                    client.query(
+                        "FOR s IN @@symbols FILTER s.file_path IN @paths REMOVE s IN @@symbols",
+                        bind_vars={"@symbols": cols.symbols, "paths": batch},
+                    )
 
             if not file_nodes:
                 # Analysis ran but no files produced data (all failed individually)
@@ -338,7 +356,11 @@ def codebase_ingest(
         files_skipped = 0
         file_results: list[dict[str, Any]] = []
 
+        if py_files:
+            print(f"  Python: processing {len(py_files)} files...", file=sys.stderr)
+
         for i, rel_path in enumerate(py_files):
+            print(f"  [{i + 1}/{len(py_files)}] {rel_path}", file=sys.stderr)
             abs_path = Path(repo_root) / rel_path
             if not abs_path.exists():
                 continue
@@ -406,11 +428,11 @@ def codebase_ingest(
                 "symbols": result.metadata.get("symbols", {}),
             })
 
-            if (i + 1) % 50 == 0:
-                print(
-                    f"  [{i + 1}/{len(py_files)}] processed...",
-                    file=sys.stderr,
-                )
+        if py_files:
+            print(
+                f"  Python: {files_processed} processed, {files_skipped} unchanged, {chunks_created} chunks",
+                file=sys.stderr,
+            )
 
         # Resolve imports and create edges
         from core.database.import_resolver import ImportResolver

--- a/core/cli/commands/ingest.py
+++ b/core/cli/commands/ingest.py
@@ -842,45 +842,34 @@ def _process_and_store(
                     }
                 )
 
-            # Insert chunks and embeddings first so that metadata only
-            # records success after the data is actually persisted.
-            #
-            # When force=True, use overwrite to replace existing documents,
-            # then clean up orphaned chunks (safe insert-first approach).
-            # This avoids the non-atomic purge+insert pattern where a failed
-            # insert after purge would permanently lose data.
+            # IMPORTANT: Never use insert_documents(..., overwrite=True).
+            # ArangoDB's /_api/import?overwrite=true TRUNCATES the entire
+            # collection before importing — it does NOT do per-document
+            # replacement.  For force re-ingestion we surgically delete
+            # only this document's data via AQL, then insert normally.
+            # This matches the code-file ingest path (see below).
             progress(f"Storing {len(chunk_docs)} chunks in database...")
 
-            if chunk_docs:
-                client.insert_documents(col.chunks, chunk_docs, overwrite=force)
-            if embedding_docs:
-                client.insert_documents(col.embeddings, embedding_docs, overwrite=force)
-            client.insert_documents(col.metadata, [meta_doc], overwrite=force)
-
-            # After successful insert with force, clean up orphaned chunks/embeddings
-            # from previous ingestion that had more chunks than the current one.
             if force:
-                new_chunk_count = len(chunk_docs)
-                # Remove chunks with index >= new count (orphans from prior ingestion)
-                removed = client.query(
-                    f"""
-                    FOR c IN {col.chunks}
-                        FILTER c.paper_key == @key AND c.chunk_index >= @max_idx
-                        REMOVE c IN {col.chunks}
-                        RETURN OLD._key
-                    """,
-                    {"key": sanitized_id, "max_idx": new_chunk_count},
+                # Delete only THIS document's existing data (safe)
+                client.query(
+                    f"FOR c IN {col.chunks} FILTER c.paper_key == @key REMOVE c IN {col.chunks}",
+                    {"key": sanitized_id},
                 )
-                # Remove corresponding orphaned embeddings
-                if removed:
-                    client.query(
-                        f"""
-                        FOR e IN {col.embeddings}
-                            FILTER e.paper_key == @key AND e.chunk_key IN @orphan_keys
-                            REMOVE e IN {col.embeddings}
-                        """,
-                        {"key": sanitized_id, "orphan_keys": removed},
-                    )
+                client.query(
+                    f"FOR e IN {col.embeddings} FILTER e.paper_key == @key REMOVE e IN {col.embeddings}",
+                    {"key": sanitized_id},
+                )
+                client.query(
+                    f"FOR m IN {col.metadata} FILTER m._key == @key REMOVE m IN {col.metadata}",
+                    {"key": sanitized_id},
+                )
+
+            if chunk_docs:
+                client.insert_documents(col.chunks, chunk_docs, overwrite=False)
+            if embedding_docs:
+                client.insert_documents(col.embeddings, embedding_docs, overwrite=False)
+            client.insert_documents(col.metadata, [meta_doc], overwrite=False)
 
             return {
                 "success": True,

--- a/core/cli/commands/ingest.py
+++ b/core/cli/commands/ingest.py
@@ -851,7 +851,12 @@ def _process_and_store(
             progress(f"Storing {len(chunk_docs)} chunks in database...")
 
             if force:
-                # Delete only THIS document's existing data (safe)
+                # Delete only THIS document's existing data (safe).
+                # Not wrapped in a transaction: ArangoDB stream transactions
+                # do not support /_api/import (used by insert_documents),
+                # and the JS transaction API is incompatible with our HTTP/2
+                # client.  If insert fails after delete, re-running --force
+                # recovers cleanly.  This matches the code-file ingest path.
                 client.query(
                     f"FOR c IN {col.chunks} FILTER c.paper_key == @key REMOVE c IN {col.chunks}",
                     {"key": sanitized_id},

--- a/core/extractors/extractors_code.py
+++ b/core/extractors/extractors_code.py
@@ -62,14 +62,13 @@ class CodeExtractor(ExtractorBase):
         if use_tree_sitter:
             try:
                 self.tree_sitter = TreeSitterExtractor()
-                logger.info("Initialized CodeExtractor with Tree-sitter support")
+                logger.debug("Initialized CodeExtractor with Tree-sitter support")
             except Exception as e:
-                logger.warning(f"Failed to initialize Tree-sitter: {e}")
+                logger.debug("Tree-sitter unavailable, chunking will use whole-file fallback: %s", e)
                 self.tree_sitter = None
                 self.use_tree_sitter = False
         else:
             self.tree_sitter = None
-            logger.info("Initialized CodeExtractor without Tree-sitter")
 
     def extract(self, file_path: str | Path, **kwargs) -> ExtractionResult:
         """

--- a/core/extractors/extractors_treesitter.py
+++ b/core/extractors/extractors_treesitter.py
@@ -18,7 +18,6 @@ try:
     TREE_SITTER_AVAILABLE = True
 except ImportError:
     TREE_SITTER_AVAILABLE = False
-    logging.warning("Tree-sitter not available - symbol extraction disabled")
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +83,7 @@ class TreeSitterExtractor:
         self.parsers: dict[str, Any] = {}
 
         if not TREE_SITTER_AVAILABLE:
-            logger.warning("Tree-sitter not available - symbol extraction will be skipped")
+            logger.debug("Tree-sitter not installed — symbol extraction unavailable")
             return
 
         # Pre-load common language parsers


### PR DESCRIPTION
## Summary
- **Data safety**: Replace dangerous `overwrite=true` in PDF/LaTeX `ingest --force` with surgical AQL delete-by-paper_key. The ArangoDB `/_api/import?overwrite=true` parameter **truncates the entire collection**, not per-document replacement — a single `--force` reingest would destroy all other papers in the same collection.
- **HTTP 501 fix**: Batch stale symbol cleanup queries in codebase ingest (groups of 30 paths) to avoid AQL cursor pagination, which triggers `Transfer-Encoding: chunked` — unsupported on ArangoDB Unix domain sockets.
- **Cleanup**: Silence tree-sitter module-level `WARNING` on import (downgraded to `DEBUG`). Tree-sitter is an optional dependency for smarter chunking, not an error when absent.
- **UX**: Add per-file `[i/total] path` progress output to both Python and Rust phases of `codebase ingest`. No more minutes of silence on 100+ file repos.

## Test plan
- [x] `poetry run python -m compileall` passes on all modified files
- [x] `poetry run ruff check` passes on `codebase.py` and `ingest.py`
- [x] 14 codebase-related unit tests pass
- [ ] Manual: `hades codebase ingest core --force` on NL_Hecate (108 Rust files) completes with symbol materialization
- [ ] Manual: `hades ingest <paper> --force` does not destroy other papers in collection

Persephone: `task_76fd85` (bident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forced re-ingestion reliability with safer targeted deletion instead of collection-wide operations.

* **Chores**
  * Optimized database operations through batching for better performance.
  * Added per-file progress indicators during codebase analysis.
  * Refined logging levels to reduce noise and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->