### PR TITLE
feat: extract Rust use-imports as symbol-level graph edges

### DIFF
--- a/core/analyzers/rust_edge_resolver.py
+++ b/core/analyzers/rust_edge_resolver.py
@@ -147,6 +147,7 @@ class RustEdgeResolver:
         - defines: codebase_files/{file_key} → codebase_symbols/{symbol_key}
         - calls: codebase_symbols/{caller} → codebase_symbols/{callee}
         - implements: codebase_symbols/{method} → codebase_symbols/{trait}
+        - imports: codebase_files/{file_key} → codebase_symbols/{imported_symbol}
         - pyo3_exposes: codebase_symbols/{rust_fn} → (marker edge, no target)
         - ffi_exposes: codebase_symbols/{rust_fn} → (marker edge, no target)
 
@@ -237,6 +238,22 @@ class RustEdgeResolver:
                             "symbol_name": qname,
                         })
 
+            # 6. imports: file → imported symbol (from use-import extraction)
+            for imp in ra.get("imports", []):
+                target_sk = self._resolve_import_target(imp)
+                if target_sk:
+                    edge_key = (f"codebase_files/{fk}", f"codebase_symbols/{target_sk}", "imports")
+                    if edge_key not in seen:
+                        seen.add(edge_key)
+                        edges.append({
+                            "_from": f"codebase_files/{fk}",
+                            "_to": f"codebase_symbols/{target_sk}",
+                            "type": "imports",
+                            "import_name": imp.get("name", ""),
+                            "use_statement": imp.get("use_statement", ""),
+                            "source_line": imp.get("source_line", 0),
+                        })
+
         logger.info(
             "Built %d edges from %d files",
             len(edges),
@@ -289,6 +306,65 @@ class RustEdgeResolver:
         if target_name and target_name in self._symbol_index:
             prefer_file = target_file or caller_file
             sk = self._pick_best_match(self._symbol_index[target_name], prefer_file)
+            if sk:
+                return sk
+
+        return None
+
+    def _resolve_import_target(self, imp: dict[str, Any]) -> str | None:
+        """Resolve a use-import to a symbol key.
+
+        Uses the goto_definition result (target_file + target_line) to find
+        the symbol defined at that location. Falls back to name-based
+        resolution if line matching fails.
+
+        Args:
+            imp: Import dict from RustSymbolExtractor._extract_use_imports().
+                Expected keys: target_file, target_line, target_name, name.
+
+        Returns:
+            The target symbol key, or None if unresolvable.
+        """
+        target_file = imp.get("target_file", "")
+        target_line = imp.get("target_line", -1)
+        target_name = imp.get("target_name", "") or imp.get("name", "")
+
+        if not target_file:
+            return None
+
+        # Strategy 1: match by file + line — find the symbol whose
+        # definition range contains the target line
+        for node in self._file_nodes:
+            if node.get("rel_path") != target_file:
+                continue
+            ra = node.get("rust_analyzer", {})
+            for sym in ra.get("symbols", []):
+                # Symbol selection_range start line matches the goto_definition target
+                if sym.get("start_line", -1) <= target_line <= sym.get("end_line", -1):
+                    # Prefer exact name match within range
+                    if sym.get("name") == target_name:
+                        qname = sym.get("qualified_name", "")
+                        if qname:
+                            return symbol_key(target_file, qname)
+
+            # Fallback: any symbol at that start line
+            for sym in ra.get("symbols", []):
+                if sym.get("start_line") == target_line:
+                    qname = sym.get("qualified_name", "")
+                    if qname:
+                        return symbol_key(target_file, qname)
+
+        # Strategy 2: file-scoped name lookup in the symbol index
+        if target_name and target_file:
+            file_scoped = f"{target_file}::{target_name}"
+            entries = self._symbol_index.get(file_scoped, [])
+            sk = self._pick_best_match(entries, target_file)
+            if sk:
+                return sk
+
+        # Strategy 3: bare name with file preference
+        if target_name and target_name in self._symbol_index:
+            sk = self._pick_best_match(self._symbol_index[target_name], target_file)
             if sk:
                 return sk
 

--- a/core/analyzers/rust_symbol_extractor.py
+++ b/core/analyzers/rust_symbol_extractor.py
@@ -632,6 +632,10 @@ class RustSymbolExtractor:
             List of (name, 0-based line, 0-based character offset) tuples.
         """
         stripped = line.strip()
+
+        # Normalize visibility prefix: "pub use", "pub(crate) use" → "use"
+        stripped = _strip_visibility(stripped)
+
         if not stripped.startswith("use "):
             return []
 
@@ -705,6 +709,21 @@ class RustSymbolExtractor:
 
 
 # ── Module-level helpers for use-statement parsing ──────────────
+
+_VIS_PREFIX_RE = re.compile(r"^pub\s*(?:\([^)]*\)\s*)?")
+
+
+def _strip_visibility(s: str) -> str:
+    """Remove a leading visibility qualifier from a statement.
+
+    ``pub use ...``          → ``use ...``
+    ``pub(crate) use ...``   → ``use ...``
+    ``pub(in path) use ...`` → ``use ...``
+    ``use ...``              → ``use ...``  (unchanged)
+    """
+    if s.startswith("pub"):
+        return _VIS_PREFIX_RE.sub("", s, count=1)
+    return s
 
 
 def _is_word_boundary(line: str, start: int, length: int) -> bool:
@@ -856,7 +875,8 @@ def _collect_use_statements(
                 current = None
             continue
 
-        if not stripped.startswith("use "):
+        # Normalize visibility prefix so "pub use" / "pub(crate) use" are recognized
+        if not _strip_visibility(stripped).startswith("use "):
             continue
 
         if ";" in stripped:

--- a/core/analyzers/rust_symbol_extractor.py
+++ b/core/analyzers/rust_symbol_extractor.py
@@ -529,13 +529,44 @@ class RustSymbolExtractor:
         imports: list[dict[str, Any]] = []
         lines = file_content.splitlines()
 
-        for line_no, line in enumerate(lines):
-            stripped = line.strip()
-            if not stripped.startswith("use "):
-                continue
+        # Assemble complete use statements (may span multiple lines) and
+        # record which original lines they came from.  Each entry is
+        # (start_line_no, list_of_(line_no, raw_line) pairs).
+        use_stmts = _collect_use_statements(lines)
 
-            # Parse terminal identifiers and their character positions
-            positions = self._parse_use_positions(line, line_no)
+        for start_line, span_lines in use_stmts:
+            # Build a single normalized statement for parsing:
+            # join continuation lines, strip inline comments.
+            joined = " ".join(raw.strip() for _, raw in span_lines)
+            # Strip trailing inline comment (after the semicolon)
+            semi_pos = joined.find(";")
+            if semi_pos != -1:
+                joined = joined[: semi_pos + 1]
+
+            # For single-line statements we pass the original line so
+            # column positions map directly to the source.  For multiline
+            # we pass the joined form and use (start_line, col) — the LSP
+            # still resolves correctly because goto_definition only needs
+            # a position that lands on the identifier token, and for
+            # multiline use-stmts rust-analyzer associates the whole
+            # statement with the opening line.
+            if len(span_lines) == 1:
+                orig_line_no, orig_line = span_lines[0]
+                # Truncate at semicolon to strip inline comments.
+                # Column positions are preserved since the prefix is unchanged.
+                semi_pos = orig_line.find(";")
+                parse_line = orig_line[: semi_pos + 1] if semi_pos != -1 else orig_line
+                positions = self._parse_use_positions(parse_line, orig_line_no)
+            else:
+                # Multiline: parse from joined text.  Column positions
+                # refer to the joined string, but we need real (line, col)
+                # for goto_definition.  Build a mapping from joined-offset
+                # back to (line_no, col).
+                positions_raw = self._parse_use_positions(joined, start_line)
+                positions = _remap_multiline_positions(
+                    positions_raw, span_lines, joined,
+                )
+
             if not positions:
                 continue
 
@@ -560,7 +591,7 @@ class RustSymbolExtractor:
                 target_file = self._uri_to_rel_path(target_uri)
 
                 # Filter: only keep imports that resolve within the crate
-                if target_file.startswith("/") or target_file == target_uri:
+                if Path(target_file).is_absolute() or target_file == target_uri:
                     # Absolute path or unresolvable URI → external crate
                     continue
 
@@ -568,8 +599,8 @@ class RustSymbolExtractor:
 
                 imports.append({
                     "name": name,
-                    "use_statement": stripped,
-                    "source_line": line_no,
+                    "use_statement": joined.strip(),
+                    "source_line": start_line,
                     "target_file": target_file,
                     "target_line": target_line,
                     "target_name": name,
@@ -791,3 +822,92 @@ def _split_respecting_braces(s: str) -> list[str]:
         parts.append("".join(current))
 
     return parts
+
+
+def _collect_use_statements(
+    lines: list[str],
+) -> list[tuple[int, list[tuple[int, str]]]]:
+    """Collect complete ``use`` statements, joining continuation lines.
+
+    Rust ``use`` statements may span multiple lines::
+
+        use std::{
+            io::Read,
+            fmt::Display,
+        };
+
+    Returns a list of ``(start_line_no, [(line_no, raw_line), ...])``.
+    Each entry is one complete ``use ...;`` statement with all its
+    contributing source lines.
+    """
+    result: list[tuple[int, list[tuple[int, str]]]] = []
+    current: list[tuple[int, str]] | None = None
+    start_line = 0
+
+    for line_no, line in enumerate(lines):
+        stripped = line.strip()
+
+        if current is not None:
+            # Continuation of a multiline use statement
+            current.append((line_no, line))
+            if ";" in stripped:
+                result.append((start_line, current))
+                current = None
+            continue
+
+        if not stripped.startswith("use "):
+            continue
+
+        if ";" in stripped:
+            # Single-line use statement (most common case)
+            result.append((line_no, [(line_no, line)]))
+        else:
+            # Multiline use statement — starts here, continues until ";"
+            current = [(line_no, line)]
+            start_line = line_no
+
+    # Unterminated use statement at EOF — include as-is so partial
+    # parsing can still extract what it can.
+    if current is not None:
+        result.append((start_line, current))
+
+    return result
+
+
+def _remap_multiline_positions(
+    positions: list[tuple[str, int, int]],
+    span_lines: list[tuple[int, str]],
+    joined: str,
+) -> list[tuple[str, int, int]]:
+    """Map column positions in a joined string back to real (line, col).
+
+    ``_parse_use_positions`` was given the joined (single-line) form of a
+    multiline ``use`` statement.  The returned column offsets refer to that
+    joined string.  This function finds which original source line each
+    name actually lives on and computes the real column.
+
+    Args:
+        positions: ``(name, start_line, col_in_joined)`` from the parser.
+        span_lines: ``[(line_no, raw_line), ...]`` — the original lines.
+        joined: The joined string that was parsed.
+
+    Returns:
+        ``(name, real_line_no, real_col)`` tuples.
+    """
+    remapped: list[tuple[str, int, int]] = []
+    for name, _, col_in_joined in positions:
+        # For each name, find which original line contains it by
+        # searching for the name token in each contributing line.
+        found = False
+        for real_line_no, raw_line in span_lines:
+            idx = _find_word(raw_line, name)
+            if idx != -1:
+                remapped.append((name, real_line_no, idx))
+                found = True
+                break
+        if not found:
+            # Fallback: use the start line and joined column.
+            # This can happen if the name only appears in the joined
+            # form (unlikely but defensive).
+            remapped.append((name, span_lines[0][0], col_in_joined))
+    return remapped

--- a/core/analyzers/rust_symbol_extractor.py
+++ b/core/analyzers/rust_symbol_extractor.py
@@ -628,16 +628,24 @@ class RustSymbolExtractor:
             parts = body.split("::")
             name = parts[-1].strip()
             if name and name.isidentifier() and name != "self":
-                # Find the character position in the original line
-                # Search backwards from end to find the terminal name
-                idx = line.rfind(name)
+                # Find the character position in the original line (word-boundary safe)
+                search_end = len(line)
                 if " as " in line:
-                    # Make sure we find the name before "as", not after
+                    # Constrain search to before the alias keyword
                     as_pos = line.find(" as ")
-                    # Search for name only in the portion before "as"
-                    idx = line.rfind(name, 0, as_pos) if as_pos != -1 else idx
-                if idx >= 0:
-                    results.append((name, line_no, idx))
+                    if as_pos != -1:
+                        search_end = as_pos
+                # Search backwards for a whole-word match
+                idx = search_end
+                while idx > 0:
+                    idx = line.rfind(name, 0, idx)
+                    if idx == -1:
+                        break
+                    if _is_word_boundary(line, idx, len(name)):
+                        results.append((name, line_no, idx))
+                        break
+                    # Not a word boundary — keep searching leftward
+                    idx -= 1
 
         return results
 
@@ -667,18 +675,55 @@ class RustSymbolExtractor:
 # ── Module-level helpers for use-statement parsing ──────────────
 
 
+def _is_word_boundary(line: str, start: int, length: int) -> bool:
+    """Check that ``line[start:start+length]`` is a whole-word match.
+
+    The character before *start* and after *start+length-1* (if they exist)
+    must not be identifier characters (letter, digit, underscore).
+    """
+    if start > 0 and (line[start - 1].isalnum() or line[start - 1] == "_"):
+        return False
+    end = start + length
+    if end < len(line) and (line[end].isalnum() or line[end] == "_"):
+        return False
+    return True
+
+
+def _find_word(line: str, name: str, start: int = 0) -> int:
+    """Find ``name`` in ``line`` at a word boundary, searching from *start*.
+
+    Returns the index, or -1 if not found.
+    """
+    idx = start
+    while True:
+        idx = line.find(name, idx)
+        if idx == -1:
+            return -1
+        if _is_word_boundary(line, idx, len(name)):
+            return idx
+        idx += 1
+
+
 def _extract_group_terminals(
     use_stmt: str,
     original_line: str,
     line_no: int,
     results: list[tuple[str, int, int]],
+    used_cols: set[int] | None = None,
 ) -> None:
     """Extract terminal identifiers from grouped/nested ``use`` statements.
 
     Walks the characters inside braces to find identifiers that are
     terminal (not followed by ``::``).  Handles nested groups like
     ``use std::{io::{Read, Write}, fmt::Display};``
+
+    *used_cols* tracks column positions already claimed on this line so
+    that duplicate identifiers (e.g. ``use a::{Foo, b::Foo}``) resolve
+    to distinct positions.
     """
+    if used_cols is None:
+        used_cols = set()
+
     brace_start = use_stmt.find("{")
     brace_end = use_stmt.rfind("}")
     if brace_start == -1 or brace_end == -1:
@@ -695,7 +740,7 @@ def _extract_group_terminals(
         if "{" in item:
             # Nested group: "io::{Read, Write}" — recurse
             synthetic = f"use {item};"
-            _extract_group_terminals(synthetic, original_line, line_no, results)
+            _extract_group_terminals(synthetic, original_line, line_no, results, used_cols)
             continue
 
         # Remove alias
@@ -710,9 +755,17 @@ def _extract_group_terminals(
         parts = item.split("::")
         name = parts[-1].strip()
         if name and name.isidentifier() and name != "self":
-            idx = original_line.find(name)
-            if idx >= 0:
-                results.append((name, line_no, idx))
+            # Search for a word-boundary match not yet claimed
+            search_from = 0
+            while True:
+                idx = _find_word(original_line, name, search_from)
+                if idx == -1:
+                    break
+                if idx not in used_cols:
+                    used_cols.add(idx)
+                    results.append((name, line_no, idx))
+                    break
+                search_from = idx + 1
 
 
 def _split_respecting_braces(s: str) -> list[str]:

--- a/core/analyzers/rust_symbol_extractor.py
+++ b/core/analyzers/rust_symbol_extractor.py
@@ -124,11 +124,15 @@ class RustSymbolExtractor:
         pyo3_exports = [s["name"] for s in symbols if s.get("is_pyo3")]
         ffi_boundaries = [s["name"] for s in symbols if s.get("is_ffi")]
 
+        # Extract use-imports via goto_definition (file-level)
+        imports = self._extract_use_imports(file_path, file_content)
+
         return {
             "symbols": symbols,
             "impl_blocks": impl_blocks,
             "pyo3_exports": pyo3_exports,
             "ffi_boundaries": ffi_boundaries,
+            "imports": imports,
             "analyzed_at": datetime.now(UTC).isoformat(),
         }
 
@@ -493,6 +497,150 @@ class RustSymbolExtractor:
             for (parent, trait), methods in blocks.items()
         ]
 
+    # ── Use-import extraction ─────────────────────────────────────
+
+    def _extract_use_imports(
+        self, file_path: str | Path, file_content: str
+    ) -> list[dict[str, Any]]:
+        """Extract ``use`` declarations and resolve each imported name via LSP.
+
+        Parses file content for ``use`` statements, identifies the terminal
+        identifiers (the names actually brought into scope), and calls
+        ``goto_definition`` on each to resolve to the definition site.
+
+        Only imports that resolve to files within the crate root are kept
+        (external crates like ``std``, ``serde`` are filtered out).
+
+        Returns:
+            List of import dicts::
+
+                {
+                    "name": "HashMap",
+                    "use_statement": "use std::collections::HashMap;",
+                    "source_line": 5,
+                    "target_file": "src/collections/hash/map.rs",
+                    "target_line": 42,
+                    "target_name": "HashMap",
+                    "qualified_name": "HashMap",
+                }
+
+            Only internal (in-crate) imports are included.
+        """
+        imports: list[dict[str, Any]] = []
+        lines = file_content.splitlines()
+
+        for line_no, line in enumerate(lines):
+            stripped = line.strip()
+            if not stripped.startswith("use "):
+                continue
+
+            # Parse terminal identifiers and their character positions
+            positions = self._parse_use_positions(line, line_no)
+            if not positions:
+                continue
+
+            for name, lsp_line, lsp_char in positions:
+                try:
+                    locations = self._session.goto_definition(
+                        file_path, lsp_line, lsp_char,
+                        timeout=5.0, retries=1, retry_delay=0.5,
+                    )
+                except Exception:
+                    logger.debug(
+                        "goto_definition failed for use '%s' at %s:%d:%d",
+                        name, file_path, lsp_line, lsp_char,
+                    )
+                    continue
+
+                if not locations:
+                    continue
+
+                loc = locations[0]
+                target_uri = loc.get("uri", "")
+                target_file = self._uri_to_rel_path(target_uri)
+
+                # Filter: only keep imports that resolve within the crate
+                if target_file.startswith("/") or target_file == target_uri:
+                    # Absolute path or unresolvable URI → external crate
+                    continue
+
+                target_line = loc.get("range", {}).get("start", {}).get("line", 0)
+
+                imports.append({
+                    "name": name,
+                    "use_statement": stripped,
+                    "source_line": line_no,
+                    "target_file": target_file,
+                    "target_line": target_line,
+                    "target_name": name,
+                    "qualified_name": name,
+                })
+
+        logger.debug(
+            "Extracted %d internal use-imports from %s", len(imports), file_path,
+        )
+        return imports
+
+    @staticmethod
+    def _parse_use_positions(
+        line: str, line_no: int
+    ) -> list[tuple[str, int, int]]:
+        """Parse a ``use`` line and return ``(name, line, col)`` per imported symbol.
+
+        Handles common Rust ``use`` patterns:
+
+        - Simple: ``use crate::module::Name;``
+        - Grouped: ``use crate::module::{A, B, C};``
+        - Aliased: ``use crate::module::Name as Alias;``
+        - Self: ``use crate::module::{self, Name};`` (``self`` skipped)
+        - Glob: ``use crate::module::*;`` (skipped entirely)
+        - Nested groups: ``use std::{io::{Read, Write}, fmt};``
+
+        Returns:
+            List of (name, 0-based line, 0-based character offset) tuples.
+        """
+        stripped = line.strip()
+        if not stripped.startswith("use "):
+            return []
+
+        # Skip glob imports — can't resolve individually
+        if stripped.rstrip(";").rstrip().endswith("*"):
+            return []
+
+        results: list[tuple[str, int, int]] = []
+
+        # Check for grouped imports (any braces present)
+        brace_open = stripped.find("{")
+        if brace_open != -1:
+            # Extract all terminal identifiers inside braces (handles nesting)
+            # We find identifiers that are followed by , or } or " as " or ;
+            # but NOT followed by :: (those are path segments, not terminals)
+            _extract_group_terminals(stripped, line, line_no, results)
+        else:
+            # Simple: use path::to::Name; or use path::to::Name as Alias;
+            body = stripped[4:].rstrip(";").strip()
+
+            # Remove alias: "Name as Alias" → "Name"
+            if " as " in body:
+                body = body.split(" as ")[0].strip()
+
+            # Get the terminal identifier (last path segment)
+            parts = body.split("::")
+            name = parts[-1].strip()
+            if name and name.isidentifier() and name != "self":
+                # Find the character position in the original line
+                # Search backwards from end to find the terminal name
+                idx = line.rfind(name)
+                if " as " in line:
+                    # Make sure we find the name before "as", not after
+                    as_pos = line.find(" as ")
+                    # Search for name only in the portion before "as"
+                    idx = line.rfind(name, 0, as_pos) if as_pos != -1 else idx
+                if idx >= 0:
+                    results.append((name, line_no, idx))
+
+        return results
+
     def _uri_to_rel_path(self, uri: str) -> str:
         """Convert a file:// URI to a path relative to the crate root."""
         if uri.startswith("file://"):
@@ -511,5 +659,82 @@ class RustSymbolExtractor:
             "impl_blocks": [],
             "pyo3_exports": [],
             "ffi_boundaries": [],
+            "imports": [],
             "analyzed_at": datetime.now(UTC).isoformat(),
         }
+
+
+# ── Module-level helpers for use-statement parsing ──────────────
+
+
+def _extract_group_terminals(
+    use_stmt: str,
+    original_line: str,
+    line_no: int,
+    results: list[tuple[str, int, int]],
+) -> None:
+    """Extract terminal identifiers from grouped/nested ``use`` statements.
+
+    Walks the characters inside braces to find identifiers that are
+    terminal (not followed by ``::``).  Handles nested groups like
+    ``use std::{io::{Read, Write}, fmt::Display};``
+    """
+    brace_start = use_stmt.find("{")
+    brace_end = use_stmt.rfind("}")
+    if brace_start == -1 or brace_end == -1:
+        return
+
+    inner = use_stmt[brace_start + 1 : brace_end]
+    items = _split_respecting_braces(inner)
+
+    for item in items:
+        item = item.strip()
+        if not item or item == "self":
+            continue
+
+        if "{" in item:
+            # Nested group: "io::{Read, Write}" — recurse
+            synthetic = f"use {item};"
+            _extract_group_terminals(synthetic, original_line, line_no, results)
+            continue
+
+        # Remove alias
+        if " as " in item:
+            item = item.split(" as ")[0].strip()
+
+        # Skip globs
+        if item.endswith("*"):
+            continue
+
+        # Get terminal name (last path segment)
+        parts = item.split("::")
+        name = parts[-1].strip()
+        if name and name.isidentifier() and name != "self":
+            idx = original_line.find(name)
+            if idx >= 0:
+                results.append((name, line_no, idx))
+
+
+def _split_respecting_braces(s: str) -> list[str]:
+    """Split a string on commas, but respect nested ``{...}`` groups."""
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+
+    for ch in s:
+        if ch == "{":
+            depth += 1
+            current.append(ch)
+        elif ch == "}":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+
+    if current:
+        parts.append("".join(current))
+
+    return parts

--- a/core/analyzers/rust_symbol_extractor.py
+++ b/core/analyzers/rust_symbol_extractor.py
@@ -25,6 +25,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from core.analyzers.lsp_client import LspError
 from core.analyzers.rust_analyzer_client import RustAnalyzerSession
 
 logger = logging.getLogger(__name__)
@@ -576,10 +577,10 @@ class RustSymbolExtractor:
                         file_path, lsp_line, lsp_char,
                         timeout=5.0, retries=1, retry_delay=0.5,
                     )
-                except Exception:
+                except LspError as e:
                     logger.debug(
-                        "goto_definition failed for use '%s' at %s:%d:%d",
-                        name, file_path, lsp_line, lsp_char,
+                        "goto_definition failed for use '%s' at %s:%d:%d: %s",
+                        name, file_path, lsp_line, lsp_char, e,
                     )
                     continue
 

--- a/core/cli/commands/codebase.py
+++ b/core/cli/commands/codebase.py
@@ -204,7 +204,7 @@ def _analyze_rust_crate(
 
             # Clear stale symbols and edges for ALL attempted files BEFORE inserting new ones.
             # This uses the OLD symbol IDs so renamed/removed symbols get cleaned up.
-            rust_edge_types = ["defines", "calls", "implements", "pyo3_exposes", "ffi_exposes"]
+            rust_edge_types = ["defines", "calls", "implements", "pyo3_exposes", "ffi_exposes", "imports"]
 
             # Check whether symbol/edge collections exist yet (they may not on first run)
             col_resp = client.request("GET", f"/_db/{db_name}/_api/collection")

--- a/tests/core/analyzers/test_rust_use_imports.py
+++ b/tests/core/analyzers/test_rust_use_imports.py
@@ -84,10 +84,22 @@ class TestParseUsePositions:
         assert results[0][0] == "Bar"
 
     def test_pub_use(self) -> None:
-        """pub use is not a 'use ' line (starts with 'pub'), should be skipped."""
-        # pub use re-exports are different from imports — skip for now
+        """pub use re-exports create a dependency — should be parsed."""
         results = self._parse("pub use crate::foo::Bar;")
-        assert len(results) == 0
+        assert len(results) == 1
+        assert results[0][0] == "Bar"
+
+    def test_pub_crate_use(self) -> None:
+        """pub(crate) use should also be parsed."""
+        results = self._parse("pub(crate) use crate::foo::Baz;")
+        assert len(results) == 1
+        assert results[0][0] == "Baz"
+
+    def test_pub_use_grouped(self) -> None:
+        """pub use with grouped imports."""
+        results = self._parse("pub use crate::foo::{Alpha, Beta};")
+        names = {r[0] for r in results}
+        assert names == {"Alpha", "Beta"}
 
     def test_single_segment(self) -> None:
         """use SomeName; (no :: path) should capture the name."""

--- a/tests/core/analyzers/test_rust_use_imports.py
+++ b/tests/core/analyzers/test_rust_use_imports.py
@@ -102,6 +102,25 @@ class TestParseUsePositions:
         assert "Bar" in names
         assert "F" not in names
 
+    def test_duplicate_name_in_group_gets_distinct_positions(self) -> None:
+        """use a::{Foo, b::Foo} — each Foo should get a distinct column."""
+        line = "use a::{Foo, b::Foo};"
+        results = self._parse(line)
+        assert len(results) == 2
+        cols = [r[2] for r in results]
+        assert cols[0] != cols[1], f"Both Foo got the same column: {cols}"
+
+    def test_substring_not_matched(self) -> None:
+        """use crate::add_things::add — should match 'add' not inside 'add_things'."""
+        line = "use crate::add_things::add;"
+        results = self._parse(line)
+        assert len(results) == 1
+        name, _, col = results[0]
+        assert name == "add"
+        # The column should point to the terminal "add", not inside "add_things"
+        assert line[col:col + 3] == "add"
+        assert col > line.find("add_things")
+
 
 # ── Part 2: Import edge resolution ──────────────────────────────
 
@@ -368,10 +387,8 @@ class TestUseImportIntegration:
     @pytest.fixture
     def session(self, rust_crate: Path):
         from core.analyzers.rust_analyzer_client import RustAnalyzerSession
-        s = RustAnalyzerSession(rust_crate, timeout=60)
-        s.start()
-        yield s
-        s.shutdown()
+        with RustAnalyzerSession(rust_crate, timeout=60) as s:
+            yield s
 
     @pytest.fixture
     def extractor(self, session):

--- a/tests/core/analyzers/test_rust_use_imports.py
+++ b/tests/core/analyzers/test_rust_use_imports.py
@@ -122,6 +122,94 @@ class TestParseUsePositions:
         assert col > line.find("add_things")
 
 
+# ── Part 1b: _collect_use_statements ─────────────────────────────
+
+
+class TestCollectUseStatements:
+    """Test multiline and inline-comment handling."""
+
+    @staticmethod
+    def _collect(source: str):
+        from core.analyzers.rust_symbol_extractor import _collect_use_statements
+        return _collect_use_statements(source.splitlines())
+
+    def test_single_line(self) -> None:
+        stmts = self._collect("use crate::foo::Bar;")
+        assert len(stmts) == 1
+        start, spans = stmts[0]
+        assert start == 0
+        assert len(spans) == 1
+
+    def test_multiline_joined(self) -> None:
+        source = textwrap.dedent("""\
+            use std::{
+                io::Read,
+                fmt::Display,
+            };
+        """)
+        stmts = self._collect(source)
+        assert len(stmts) == 1
+        start, spans = stmts[0]
+        assert start == 0
+        assert len(spans) == 4  # 4 lines including closing };
+
+    def test_inline_comment_stripped_by_caller(self) -> None:
+        """Inline comments after ; should not interfere with parsing."""
+        source = "use crate::foo::Bar; // a note"
+        stmts = self._collect(source)
+        assert len(stmts) == 1
+        # When the caller joins + truncates at ";", the comment is removed.
+        _, spans = stmts[0]
+        joined = " ".join(raw.strip() for _, raw in spans)
+        semi = joined.find(";")
+        cleaned = joined[: semi + 1]
+        assert "//" not in cleaned
+        # The name should still parse correctly
+        results = RustSymbolExtractor._parse_use_positions(cleaned, 0)
+        assert len(results) == 1
+        assert results[0][0] == "Bar"
+
+    def test_multiline_parse_positions(self) -> None:
+        """Terminal names in a multiline use statement should be found."""
+        source = textwrap.dedent("""\
+            use crate::{
+                Alpha,
+                Beta,
+            };
+        """)
+        stmts = self._collect(source)
+        assert len(stmts) == 1
+        _, spans = stmts[0]
+        joined = " ".join(raw.strip() for _, raw in spans)
+        semi = joined.find(";")
+        cleaned = joined[: semi + 1]
+        results = RustSymbolExtractor._parse_use_positions(cleaned, 0)
+        names = {r[0] for r in results}
+        assert names == {"Alpha", "Beta"}
+
+    def test_mixed_single_and_multiline(self) -> None:
+        source = textwrap.dedent("""\
+            use crate::foo::A;
+            use crate::{
+                B,
+                C,
+            };
+            use crate::bar::D;
+        """)
+        stmts = self._collect(source)
+        assert len(stmts) == 3
+
+    def test_non_use_lines_skipped(self) -> None:
+        source = textwrap.dedent("""\
+            fn main() {}
+            let x = 5;
+            use crate::foo::Bar;
+        """)
+        stmts = self._collect(source)
+        assert len(stmts) == 1
+        assert stmts[0][0] == 2  # line index 2
+
+
 # ── Part 2: Import edge resolution ──────────────────────────────
 
 
@@ -360,11 +448,16 @@ class TestUseImportIntegration:
         (src / "lib.rs").write_text(textwrap.dedent("""\
             pub mod math;
             pub mod consumer;
+            pub mod multiline_consumer;
         """))
 
         (src / "math.rs").write_text(textwrap.dedent("""\
             pub fn add(a: i32, b: i32) -> i32 {
                 a + b
+            }
+
+            pub fn multiply(a: i32, b: i32) -> i32 {
+                a * b
             }
 
             pub struct Calculator {
@@ -373,12 +466,24 @@ class TestUseImportIntegration:
         """))
 
         (src / "consumer.rs").write_text(textwrap.dedent("""\
-            use crate::math::add;
+            use crate::math::add; // inline comment
             use crate::math::Calculator;
 
             pub fn compute() -> i32 {
                 let c = Calculator { total: 0 };
                 add(c.total, 1)
+            }
+        """))
+
+        # Multiline use statement
+        (src / "multiline_consumer.rs").write_text(textwrap.dedent("""\
+            use crate::math::{
+                add,
+                multiply,
+            };
+
+            pub fn compute_both(a: i32, b: i32) -> i32 {
+                add(a, multiply(a, b))
             }
         """))
 
@@ -413,9 +518,27 @@ class TestUseImportIntegration:
             assert imp["target_file"], f"Import {imp['name']} has no target_file"
             assert "math.rs" in imp["target_file"]
 
+    def test_inline_comment_does_not_break_import(self, extractor: RustSymbolExtractor) -> None:
+        """use foo::Bar; // comment — should still resolve Bar."""
+        data = extractor.extract_file("src/consumer.rs")
+        imports = data["imports"]
+        names = {imp["name"] for imp in imports}
+        assert "add" in names, f"Inline comment broke import resolution: {names}"
+
+    def test_multiline_use_resolved(self, extractor: RustSymbolExtractor) -> None:
+        """Multiline use crate::{\\n  add,\\n  multiply,\\n}; should resolve both."""
+        data = extractor.extract_file("src/multiline_consumer.rs")
+        imports = data["imports"]
+        names = {imp["name"] for imp in imports}
+        assert len(imports) > 0, "Multiline use statement produced no imports"
+        # At least one of the two should resolve
+        assert names & {"add", "multiply"}, f"Expected add or multiply in {names}"
+
     def test_full_pipeline_edges(self, extractor: RustSymbolExtractor) -> None:
         """Extract all files, then build edges — imports should appear."""
-        results = extractor.extract_crate(["src/lib.rs", "src/math.rs", "src/consumer.rs"])
+        results = extractor.extract_crate([
+            "src/lib.rs", "src/math.rs", "src/consumer.rs", "src/multiline_consumer.rs",
+        ])
         file_nodes = [
             {"rel_path": path, "rust_analyzer": data}
             for path, data in results.items()

--- a/tests/core/analyzers/test_rust_use_imports.py
+++ b/tests/core/analyzers/test_rust_use_imports.py
@@ -1,0 +1,416 @@
+"""Tests for Rust use-import extraction and edge resolution.
+
+Part 1: _parse_use_positions — pure parsing, no LSP needed.
+Part 2: Import edge resolution via RustEdgeResolver.
+Part 3: Integration test with real rust-analyzer (skipped if not installed).
+"""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from core.analyzers.rust_edge_resolver import RustEdgeResolver, symbol_key
+from core.analyzers.rust_symbol_extractor import RustSymbolExtractor
+from core.database.keys import file_key
+
+# ── Part 1: _parse_use_positions ─────────────────────────────────
+
+
+class TestParseUsePositions:
+    """Test the static use-statement parser (no LSP needed)."""
+
+    @staticmethod
+    def _parse(line: str, line_no: int = 0) -> list[tuple[str, int, int]]:
+        return RustSymbolExtractor._parse_use_positions(line, line_no)
+
+    def test_simple_import(self) -> None:
+        results = self._parse("use crate::module::Name;")
+        assert len(results) == 1
+        name, line, col = results[0]
+        assert name == "Name"
+        assert line == 0
+        assert col == "use crate::module::Name;".find("Name")
+
+    def test_aliased_import(self) -> None:
+        results = self._parse("use crate::module::Name as Alias;")
+        assert len(results) == 1
+        name, _, col = results[0]
+        assert name == "Name"
+        # Should point to Name, not Alias
+        assert col == "use crate::module::Name as Alias;".find("Name")
+
+    def test_grouped_import(self) -> None:
+        results = self._parse("use crate::module::{Alpha, Beta, Gamma};")
+        names = {r[0] for r in results}
+        assert names == {"Alpha", "Beta", "Gamma"}
+
+    def test_grouped_with_self_skipped(self) -> None:
+        results = self._parse("use crate::module::{self, Name};")
+        names = {r[0] for r in results}
+        assert "self" not in names
+        assert "Name" in names
+
+    def test_glob_skipped(self) -> None:
+        results = self._parse("use crate::module::*;")
+        assert len(results) == 0
+
+    def test_grouped_glob_skipped(self) -> None:
+        """A glob inside a group should be skipped but other items kept."""
+        results = self._parse("use crate::{module::*, Name};")
+        names = {r[0] for r in results}
+        assert "Name" in names
+
+    def test_nested_groups(self) -> None:
+        results = self._parse("use std::{io::{Read, Write}, fmt::Display};")
+        names = {r[0] for r in results}
+        assert names == {"Read", "Write", "Display"}
+
+    def test_not_a_use_statement(self) -> None:
+        assert self._parse("let x = 5;") == []
+        assert self._parse("// use crate::foo;") == []
+
+    def test_line_number_preserved(self) -> None:
+        results = self._parse("use crate::foo::Bar;", line_no=42)
+        assert results[0][1] == 42
+
+    def test_indented_use(self) -> None:
+        """Leading whitespace should not break parsing."""
+        results = self._parse("    use crate::foo::Bar;")
+        assert len(results) == 1
+        assert results[0][0] == "Bar"
+
+    def test_pub_use(self) -> None:
+        """pub use is not a 'use ' line (starts with 'pub'), should be skipped."""
+        # pub use re-exports are different from imports — skip for now
+        results = self._parse("pub use crate::foo::Bar;")
+        assert len(results) == 0
+
+    def test_single_segment(self) -> None:
+        """use SomeName; (no :: path) should capture the name."""
+        results = self._parse("use SomeName;")
+        assert len(results) == 1
+        assert results[0][0] == "SomeName"
+
+    def test_alias_in_group(self) -> None:
+        results = self._parse("use crate::{Foo as F, Bar};")
+        names = {r[0] for r in results}
+        assert "Foo" in names
+        assert "Bar" in names
+        assert "F" not in names
+
+
+# ── Part 2: Import edge resolution ──────────────────────────────
+
+
+def _make_file_node(
+    rel_path: str,
+    symbols: list[dict],
+    imports: list[dict] | None = None,
+) -> dict:
+    """Build a file node with rust_analyzer attribute."""
+    return {
+        "rel_path": rel_path,
+        "rust_analyzer": {
+            "symbols": symbols,
+            "impl_blocks": [],
+            "pyo3_exports": [],
+            "ffi_boundaries": [],
+            "imports": imports or [],
+            "analyzed_at": "2026-04-06T00:00:00+00:00",
+        },
+    }
+
+
+@pytest.fixture
+def math_file() -> dict:
+    return _make_file_node(
+        "src/math.rs",
+        symbols=[
+            {
+                "name": "add",
+                "qualified_name": "add",
+                "kind": "function",
+                "visibility": "pub",
+                "start_line": 0,
+                "end_line": 2,
+            },
+            {
+                "name": "multiply",
+                "qualified_name": "multiply",
+                "kind": "function",
+                "visibility": "pub",
+                "start_line": 4,
+                "end_line": 6,
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def model_file_with_imports(math_file: dict) -> dict:
+    """model.rs that imports add and multiply from math.rs."""
+    return _make_file_node(
+        "src/model.rs",
+        symbols=[
+            {
+                "name": "Model",
+                "qualified_name": "Model",
+                "kind": "struct",
+                "visibility": "pub",
+                "start_line": 4,
+                "end_line": 7,
+            },
+        ],
+        imports=[
+            {
+                "name": "add",
+                "use_statement": "use crate::math::add;",
+                "source_line": 0,
+                "target_file": "src/math.rs",
+                "target_line": 0,
+                "target_name": "add",
+                "qualified_name": "add",
+            },
+            {
+                "name": "multiply",
+                "use_statement": "use crate::math::multiply;",
+                "source_line": 1,
+                "target_file": "src/math.rs",
+                "target_line": 4,
+                "target_name": "multiply",
+                "qualified_name": "multiply",
+            },
+        ],
+    )
+
+
+class TestImportEdgeResolution:
+    """Test that import edges are correctly built from pre-extracted import data."""
+
+    def test_import_edges_created(self, math_file: dict, model_file_with_imports: dict) -> None:
+        resolver = RustEdgeResolver([math_file, model_file_with_imports])
+        edges = resolver.build_edges()
+        imports = [e for e in edges if e["type"] == "imports"]
+        assert len(imports) == 2
+
+    def test_import_edge_source_is_file(self, math_file: dict, model_file_with_imports: dict) -> None:
+        resolver = RustEdgeResolver([math_file, model_file_with_imports])
+        edges = resolver.build_edges()
+        imports = [e for e in edges if e["type"] == "imports"]
+        fk = file_key("src/model.rs")
+        for e in imports:
+            assert e["_from"] == f"codebase_files/{fk}"
+
+    def test_import_edge_target_is_symbol(self, math_file: dict, model_file_with_imports: dict) -> None:
+        resolver = RustEdgeResolver([math_file, model_file_with_imports])
+        edges = resolver.build_edges()
+        imports = [e for e in edges if e["type"] == "imports"]
+
+        expected_targets = {
+            f"codebase_symbols/{symbol_key('src/math.rs', 'add')}",
+            f"codebase_symbols/{symbol_key('src/math.rs', 'multiply')}",
+        }
+        actual_targets = {e["_to"] for e in imports}
+        assert actual_targets == expected_targets
+
+    def test_import_edge_metadata(self, math_file: dict, model_file_with_imports: dict) -> None:
+        resolver = RustEdgeResolver([math_file, model_file_with_imports])
+        edges = resolver.build_edges()
+        imports = [e for e in edges if e["type"] == "imports"]
+        add_edge = next(e for e in imports if e["import_name"] == "add")
+        assert add_edge["use_statement"] == "use crate::math::add;"
+        assert add_edge["source_line"] == 0
+
+    def test_no_duplicate_import_edges(self, math_file: dict) -> None:
+        """Same import appearing twice should be deduplicated."""
+        dup_imports = _make_file_node(
+            "src/user.rs",
+            symbols=[],
+            imports=[
+                {
+                    "name": "add",
+                    "use_statement": "use crate::math::add;",
+                    "source_line": 0,
+                    "target_file": "src/math.rs",
+                    "target_line": 0,
+                    "target_name": "add",
+                    "qualified_name": "add",
+                },
+                {
+                    "name": "add",
+                    "use_statement": "use crate::math::add;",
+                    "source_line": 1,
+                    "target_file": "src/math.rs",
+                    "target_line": 0,
+                    "target_name": "add",
+                    "qualified_name": "add",
+                },
+            ],
+        )
+        resolver = RustEdgeResolver([math_file, dup_imports])
+        edges = resolver.build_edges()
+        imports = [e for e in edges if e["type"] == "imports"]
+        assert len(imports) == 1
+
+    def test_unresolvable_import_skipped(self) -> None:
+        """Imports pointing to files not in the file_nodes should be skipped."""
+        node = _make_file_node(
+            "src/main.rs",
+            symbols=[],
+            imports=[
+                {
+                    "name": "Ghost",
+                    "use_statement": "use crate::ghost::Ghost;",
+                    "source_line": 0,
+                    "target_file": "src/ghost.rs",
+                    "target_line": 0,
+                    "target_name": "Ghost",
+                    "qualified_name": "Ghost",
+                },
+            ],
+        )
+        resolver = RustEdgeResolver([node])
+        edges = resolver.build_edges()
+        imports = [e for e in edges if e["type"] == "imports"]
+        assert len(imports) == 0
+
+    def test_import_and_call_edges_coexist(self, math_file: dict) -> None:
+        """A file can have both imports and call edges."""
+        caller = _make_file_node(
+            "src/caller.rs",
+            symbols=[
+                {
+                    "name": "do_math",
+                    "qualified_name": "do_math",
+                    "kind": "function",
+                    "visibility": "pub",
+                    "start_line": 3,
+                    "end_line": 6,
+                    "calls": [
+                        {"qualified_name": "add", "name": "add", "file": "src/math.rs", "line": 4},
+                    ],
+                },
+            ],
+            imports=[
+                {
+                    "name": "add",
+                    "use_statement": "use crate::math::add;",
+                    "source_line": 0,
+                    "target_file": "src/math.rs",
+                    "target_line": 0,
+                    "target_name": "add",
+                    "qualified_name": "add",
+                },
+            ],
+        )
+        resolver = RustEdgeResolver([math_file, caller])
+        edges = resolver.build_edges()
+
+        edge_types = {e["type"] for e in edges}
+        assert "imports" in edge_types
+        assert "calls" in edge_types
+        assert "defines" in edge_types
+
+
+# ── Part 3: Integration with rust-analyzer ───────────────────────
+
+HAS_RUST_ANALYZER = shutil.which("rust-analyzer") is not None
+
+
+@pytest.mark.skipif(not HAS_RUST_ANALYZER, reason="rust-analyzer not installed")
+class TestUseImportIntegration:
+    """End-to-end test: extract real use-imports from a Rust crate."""
+
+    @pytest.fixture
+    def rust_crate(self, tmp_path: Path) -> Path:
+        crate = tmp_path / "import_test_crate"
+        crate.mkdir()
+        (crate / "Cargo.toml").write_text(textwrap.dedent("""\
+            [package]
+            name = "import_test_crate"
+            version = "0.1.0"
+            edition = "2021"
+        """))
+        src = crate / "src"
+        src.mkdir()
+
+        (src / "lib.rs").write_text(textwrap.dedent("""\
+            pub mod math;
+            pub mod consumer;
+        """))
+
+        (src / "math.rs").write_text(textwrap.dedent("""\
+            pub fn add(a: i32, b: i32) -> i32 {
+                a + b
+            }
+
+            pub struct Calculator {
+                pub total: i32,
+            }
+        """))
+
+        (src / "consumer.rs").write_text(textwrap.dedent("""\
+            use crate::math::add;
+            use crate::math::Calculator;
+
+            pub fn compute() -> i32 {
+                let c = Calculator { total: 0 };
+                add(c.total, 1)
+            }
+        """))
+
+        return crate
+
+    @pytest.fixture
+    def session(self, rust_crate: Path):
+        from core.analyzers.rust_analyzer_client import RustAnalyzerSession
+        s = RustAnalyzerSession(rust_crate, timeout=60)
+        s.start()
+        yield s
+        s.shutdown()
+
+    @pytest.fixture
+    def extractor(self, session):
+        return RustSymbolExtractor(session, include_calls=True, include_incoming=False)
+
+    def test_imports_field_present(self, extractor: RustSymbolExtractor) -> None:
+        data = extractor.extract_file("src/consumer.rs")
+        assert "imports" in data
+
+    def test_internal_imports_resolved(self, extractor: RustSymbolExtractor) -> None:
+        data = extractor.extract_file("src/consumer.rs")
+        imports = data["imports"]
+        # Should have at least one internal import (add or Calculator)
+        assert len(imports) > 0
+        names = {imp["name"] for imp in imports}
+        # At least one of the two use statements should resolve
+        assert names & {"add", "Calculator"}, f"Expected add or Calculator in {names}"
+
+    def test_import_has_target_file(self, extractor: RustSymbolExtractor) -> None:
+        data = extractor.extract_file("src/consumer.rs")
+        for imp in data["imports"]:
+            assert imp["target_file"], f"Import {imp['name']} has no target_file"
+            assert "math.rs" in imp["target_file"]
+
+    def test_full_pipeline_edges(self, extractor: RustSymbolExtractor) -> None:
+        """Extract all files, then build edges — imports should appear."""
+        results = extractor.extract_crate(["src/lib.rs", "src/math.rs", "src/consumer.rs"])
+        file_nodes = [
+            {"rel_path": path, "rust_analyzer": data}
+            for path, data in results.items()
+        ]
+
+        resolver = RustEdgeResolver(file_nodes)
+        edges = resolver.build_edges()
+
+        import_edges = [e for e in edges if e["type"] == "imports"]
+        assert len(import_edges) > 0, "Expected at least one import edge from consumer.rs"
+
+        # Import edges should come from consumer.rs
+        consumer_fk = file_key("src/consumer.rs")
+        consumer_imports = [e for e in import_edges if consumer_fk in e["_from"]]
+        assert len(consumer_imports) > 0


### PR DESCRIPTION
## Summary
- Closes the gap where Rust `use` statements were not tracked as edges in the codebase knowledge graph — Python had 6 import edges but Rust had 0
- Uses LSP `goto_definition` to resolve each imported name to its definition site, creating `codebase_files → codebase_symbols` edges with type `"imports"`
- Handles simple, grouped, nested, aliased, glob, and `self` use patterns; filters out external crate imports automatically

## Changes
| File | What |
|------|------|
| `core/analyzers/rust_symbol_extractor.py` | `_extract_use_imports()` + `_parse_use_positions()` — parse `use` statements, resolve via LSP, filter to internal |
| `core/analyzers/rust_edge_resolver.py` | `_resolve_import_target()` + `"imports"` edge type in `build_edges()` |
| `core/cli/commands/codebase.py` | Add `"imports"` to `rust_edge_types` for stale edge cleanup |
| `tests/core/analyzers/test_rust_use_imports.py` | 24 tests: 13 parsing, 7 edge resolution, 4 rust-analyzer integration |

## Test plan
- [x] 13 `_parse_use_positions` unit tests (simple, grouped, nested, aliased, glob, self, pub use, indented)
- [x] 7 edge resolver tests (creation, source/target validation, metadata, dedup, unresolvable skip, coexistence with calls)
- [x] 4 integration tests with real rust-analyzer (imports field present, resolved, target file correct, full pipeline edges)
- [x] All 33 existing rust analyzer tests still pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extract Rust `use` import statements with resolved targets and include source line and use text in analysis results.
  * Add import relationship edges from files to imported symbols, with deduplication and coexistence with other edge types.
  * Stale-cleanup updated to remove stale import edges.

* **Tests**
  * Comprehensive tests for parsing (single/multiline/grouped), resolution, deduplication, and optional end-to-end integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->