### PR TITLE
feat: Python AST symbol extraction and edge resolution

### DIFF
--- a/core/analyzers/python_ast_extractor.py
+++ b/core/analyzers/python_ast_extractor.py
@@ -1,0 +1,374 @@
+"""Python AST symbol extraction via the standard ``ast`` module.
+
+Extracts rich symbol data from Python files and structures it for storage
+as the ``python_ast`` attribute on codebase_files nodes.  This is the
+Python counterpart of ``RustSymbolExtractor`` (which uses rust-analyzer).
+
+The ``ast`` module gives us a *semantic* AST — scopes, name resolution,
+decorators, base classes — which tree-sitter cannot provide.  Zero
+external dependencies.
+
+Usage:
+    extractor = PythonAstExtractor()
+    file_data = extractor.extract_file("core/database/pool.py", repo_root)
+    # file_data is the dict to store as file_node["python_ast"]
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _visibility(name: str) -> str:
+    """Derive Python visibility from naming convention.
+
+    - ``__name__`` → dunder (magic / special)
+    - ``__name``   → private (name-mangled)
+    - ``_name``    → protected (conventional)
+    - ``name``     → public
+    """
+    if name.startswith("__") and name.endswith("__"):
+        return "dunder"
+    if name.startswith("__"):
+        return "private"
+    if name.startswith("_"):
+        return "protected"
+    return "public"
+
+
+def _decorator_names(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> list[str]:
+    """Extract decorator names as strings."""
+    names: list[str] = []
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name):
+            names.append(dec.id)
+        elif isinstance(dec, ast.Attribute):
+            names.append(ast.unparse(dec))
+        elif isinstance(dec, ast.Call):
+            # e.g. @decorator(args)
+            names.append(ast.unparse(dec.func))
+        else:
+            names.append(ast.unparse(dec))
+    return names
+
+
+def _base_names(node: ast.ClassDef) -> list[str]:
+    """Extract base class names."""
+    return [ast.unparse(b) for b in node.bases]
+
+
+def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Build a human-readable signature string."""
+    args = node.args
+    parts: list[str] = []
+
+    # Regular positional args
+    for arg in args.args:
+        ann = f": {ast.unparse(arg.annotation)}" if arg.annotation else ""
+        parts.append(f"{arg.arg}{ann}")
+
+    # *args
+    if args.vararg:
+        ann = f": {ast.unparse(args.vararg.annotation)}" if args.vararg.annotation else ""
+        parts.append(f"*{args.vararg.arg}{ann}")
+
+    # keyword-only args
+    for arg in args.kwonlyargs:
+        ann = f": {ast.unparse(arg.annotation)}" if arg.annotation else ""
+        parts.append(f"{arg.arg}{ann}")
+
+    # **kwargs
+    if args.kwarg:
+        ann = f": {ast.unparse(args.kwarg.annotation)}" if args.kwarg.annotation else ""
+        parts.append(f"**{args.kwarg.arg}{ann}")
+
+    ret = f" -> {ast.unparse(node.returns)}" if node.returns else ""
+    prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+    return f"{prefix} {node.name}({', '.join(parts)}){ret}"
+
+
+def _extract_calls(body: list[ast.stmt]) -> list[dict[str, str]]:
+    """Walk a function body and extract call targets.
+
+    Returns a list of dicts with ``name`` and optionally ``qualified_name``
+    (for attribute calls like ``self.foo()`` or ``module.func()``).
+    """
+    calls: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
+        if not isinstance(node, ast.Call):
+            continue
+
+        func = node.func
+        if isinstance(func, ast.Name):
+            name = func.id
+            if name not in seen:
+                seen.add(name)
+                calls.append({"name": name, "qualified_name": name})
+        elif isinstance(func, ast.Attribute):
+            attr = func.attr
+            # Reconstruct the full dotted path for simple cases
+            try:
+                full = ast.unparse(func)
+            except Exception:
+                full = attr
+            if full not in seen:
+                seen.add(full)
+                calls.append({"name": attr, "qualified_name": full})
+
+    return calls
+
+
+class PythonAstExtractor:
+    """Extract structured symbol data from Python files via ``ast``.
+
+    Produces a dict suitable for storing as the ``python_ast`` attribute
+    on a codebase_files document — structurally parallel to the
+    ``rust_analyzer`` attribute produced by ``RustSymbolExtractor``.
+    """
+
+    def extract_file(
+        self,
+        file_path: str | Path,
+        repo_root: str | Path | None = None,
+        file_content: str | None = None,
+    ) -> dict[str, Any]:
+        """Extract all symbol data for a single Python file.
+
+        Args:
+            file_path: Path to the .py file (absolute or relative).
+            repo_root: Repository root for computing relative paths.
+            file_content: Optional file content; read from disk if omitted.
+
+        Returns:
+            Dict suitable for ``file_node["python_ast"]``::
+
+                {
+                    "symbols": [...],
+                    "imports": [...],
+                    "analyzed_at": "..."
+                }
+        """
+        path = Path(file_path)
+        if repo_root and not path.is_absolute():
+            path = Path(repo_root) / path
+
+        if file_content is None:
+            try:
+                file_content = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                logger.warning("Cannot read %s", path)
+                return self._empty_result()
+
+        try:
+            tree = ast.parse(file_content, filename=str(path))
+        except SyntaxError as exc:
+            logger.warning("Syntax error in %s: %s", path, exc)
+            return self._empty_result()
+
+        symbols = self._walk_module(tree, file_content)
+        imports = self._extract_imports(tree)
+
+        return {
+            "symbols": symbols,
+            "imports": imports,
+            "analyzed_at": datetime.now(UTC).isoformat(),
+        }
+
+    # ── Internal helpers ──────────────────────────────────────────
+
+    def _walk_module(
+        self,
+        tree: ast.Module,
+        source: str,
+    ) -> list[dict[str, Any]]:
+        """Walk the AST and extract all symbol definitions."""
+        symbols: list[dict[str, Any]] = []
+        self._walk_body(tree.body, parent_name=None, symbols=symbols, source=source, in_function=False)
+        return symbols
+
+    def _walk_body(
+        self,
+        body: list[ast.stmt],
+        parent_name: str | None,
+        symbols: list[dict[str, Any]],
+        source: str,
+        *,
+        in_function: bool = False,
+    ) -> None:
+        """Recursively walk a body (module, class, function) for definitions.
+
+        Assignments are only extracted at module and class scope — local
+        variables inside functions are not symbols.
+        """
+        for node in body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._process_function(node, parent_name, symbols, source)
+
+            elif isinstance(node, ast.ClassDef):
+                self._process_class(node, parent_name, symbols, source)
+
+            elif isinstance(node, (ast.Assign, ast.AnnAssign)) and not in_function:
+                self._process_assignment(node, parent_name, symbols)
+
+    def _process_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        parent_name: str | None,
+        symbols: list[dict[str, Any]],
+        source: str,
+    ) -> None:
+        name = node.name
+        qualified = f"{parent_name}.{name}" if parent_name else name
+        kind = "method" if parent_name else "function"
+
+        # Detect static/class methods
+        decs = _decorator_names(node)
+        if "staticmethod" in decs:
+            kind = "staticmethod"
+        elif "classmethod" in decs:
+            kind = "classmethod"
+        elif "property" in decs:
+            kind = "property"
+
+        sym: dict[str, Any] = {
+            "name": name,
+            "qualified_name": qualified,
+            "kind": kind,
+            "visibility": _visibility(name),
+            "signature": _function_signature(node),
+            "start_line": node.lineno,
+            "end_line": node.end_lineno or node.lineno,
+            "parent_symbol": parent_name,
+            "decorators": decs,
+            "calls": _extract_calls(node.body),
+        }
+        symbols.append(sym)
+
+        # Walk nested definitions (closures, inner classes)
+        self._walk_body(node.body, qualified, symbols, source, in_function=True)
+
+    def _process_class(
+        self,
+        node: ast.ClassDef,
+        parent_name: str | None,
+        symbols: list[dict[str, Any]],
+        source: str,
+    ) -> None:
+        name = node.name
+        qualified = f"{parent_name}.{name}" if parent_name else name
+        decs = _decorator_names(node)
+        bases = _base_names(node)
+
+        sym: dict[str, Any] = {
+            "name": name,
+            "qualified_name": qualified,
+            "kind": "class",
+            "visibility": _visibility(name),
+            "signature": f"class {name}({', '.join(bases)})" if bases else f"class {name}",
+            "start_line": node.lineno,
+            "end_line": node.end_lineno or node.lineno,
+            "parent_symbol": parent_name,
+            "decorators": decs,
+            "bases": bases,
+        }
+        symbols.append(sym)
+
+        # Walk class body for methods, nested classes, class variables
+        self._walk_body(node.body, qualified, symbols, source, in_function=False)
+
+    def _process_assignment(
+        self,
+        node: ast.Assign | ast.AnnAssign,
+        parent_name: str | None,
+        symbols: list[dict[str, Any]],
+    ) -> None:
+        """Extract module-level constants and class-level attributes."""
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.AnnAssign) and node.target:
+            targets = [node.target]
+        elif isinstance(node, ast.Assign):
+            targets = node.targets
+
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+
+            name = target.id
+            # Only capture UPPER_CASE (constants) at module level,
+            # or all assignments at class level
+            if parent_name is None and not name.isupper():
+                continue
+
+            qualified = f"{parent_name}.{name}" if parent_name else name
+            kind = "constant" if name.isupper() else "attribute"
+
+            # Build a signature from annotation if available
+            sig = name
+            if isinstance(node, ast.AnnAssign) and node.annotation:
+                sig = f"{name}: {ast.unparse(node.annotation)}"
+
+            sym: dict[str, Any] = {
+                "name": name,
+                "qualified_name": qualified,
+                "kind": kind,
+                "visibility": _visibility(name),
+                "signature": sig,
+                "start_line": node.lineno,
+                "end_line": node.end_lineno or node.lineno,
+                "parent_symbol": parent_name,
+            }
+            symbols.append(sym)
+
+    def _extract_imports(self, tree: ast.Module) -> list[dict[str, Any]]:
+        """Extract structured import information.
+
+        Returns dicts compatible with ``ImportResolver.resolve_import()``:
+        ``{"module": "...", "name": "...", "type": "...", "line": N, "level": N}``
+        """
+        imports: list[dict[str, Any]] = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports.append({
+                        "module": alias.name,
+                        "name": alias.asname or alias.name,
+                        "type": "import",
+                        "line": node.lineno,
+                        "level": 0,
+                    })
+
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                level = node.level or 0
+
+                # For relative imports, prepend dots to module
+                if level > 0:
+                    module = "." * level + module
+
+                for alias in node.names:
+                    imports.append({
+                        "module": module,
+                        "name": alias.name,
+                        "type": "from_import",
+                        "line": node.lineno,
+                        "level": level,
+                    })
+
+        return imports
+
+    @staticmethod
+    def _empty_result() -> dict[str, Any]:
+        return {
+            "symbols": [],
+            "imports": [],
+            "analyzed_at": datetime.now(UTC).isoformat(),
+        }

--- a/core/analyzers/python_ast_extractor.py
+++ b/core/analyzers/python_ast_extractor.py
@@ -96,33 +96,41 @@ def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
 def _extract_calls(body: list[ast.stmt]) -> list[dict[str, str]]:
     """Walk a function body and extract call targets.
 
+    Only collects calls at the current scope — does NOT descend into
+    nested function/class definitions (those belong to the nested symbol).
+
     Returns a list of dicts with ``name`` and optionally ``qualified_name``
     (for attribute calls like ``self.foo()`` or ``module.func()``).
     """
     calls: list[dict[str, str]] = []
     seen: set[str] = set()
 
-    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
-        if not isinstance(node, ast.Call):
-            continue
+    def _visit(nodes: list[ast.AST]) -> None:
+        for node in nodes:
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name):
+                    name = func.id
+                    if name not in seen:
+                        seen.add(name)
+                        calls.append({"name": name, "qualified_name": name})
+                elif isinstance(func, ast.Attribute):
+                    attr = func.attr
+                    try:
+                        full = ast.unparse(func)
+                    except Exception:
+                        full = attr
+                    if full not in seen:
+                        seen.add(full)
+                        calls.append({"name": attr, "qualified_name": full})
+            # Skip nested definitions — their calls belong to their own symbol
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            # Recurse into child nodes
+            for child in ast.iter_child_nodes(node):
+                _visit([child])
 
-        func = node.func
-        if isinstance(func, ast.Name):
-            name = func.id
-            if name not in seen:
-                seen.add(name)
-                calls.append({"name": name, "qualified_name": name})
-        elif isinstance(func, ast.Attribute):
-            attr = func.attr
-            # Reconstruct the full dotted path for simple cases
-            try:
-                full = ast.unparse(func)
-            except Exception:
-                full = attr
-            if full not in seen:
-                seen.add(full)
-                calls.append({"name": attr, "qualified_name": full})
-
+    _visit(body)
     return calls
 
 

--- a/core/analyzers/python_edge_resolver.py
+++ b/core/analyzers/python_edge_resolver.py
@@ -1,0 +1,253 @@
+"""Python edge resolver — materializes symbol nodes and edges from file-node data.
+
+Reads the ``python_ast`` attribute from codebase_files nodes and derives:
+- codebase_symbols child documents (function/class/method/constant level)
+- codebase_edges: defines, calls
+
+This is the Python counterpart of ``RustEdgeResolver``.  The file node is
+the source of truth; this resolver is a "materialized view" that projects
+fine-grained queryable nodes from it.
+
+Usage:
+    resolver = PythonEdgeResolver(file_nodes)
+    symbols = resolver.build_symbol_nodes()
+    edges = resolver.build_edges()
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from core.database.keys import file_key
+
+logger = logging.getLogger(__name__)
+
+
+def symbol_key(file_rel_path: str, qualified_name: str) -> str:
+    """Build an ArangoDB-safe key for a Python codebase_symbols document.
+
+    Mirrors ``rust_edge_resolver.symbol_key`` in structure so Python and
+    Rust symbols share the same key-building convention.
+
+    Examples:
+        >>> symbol_key("core/database/pool.py", "Pool.acquire")
+        'core_database_pool_py__Pool_acquire'
+        >>> symbol_key("setup.py", "main")
+        'setup_py__main'
+    """
+    fk = file_key(file_rel_path)
+    # Replace '.' with underscore (Python scope separator)
+    safe_name = qualified_name.replace(".", "_")
+    # Replace all non-alphanumeric/underscore chars with single underscore
+    safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", safe_name)
+    # Collapse 3+ underscores to 2
+    safe_name = re.sub(r"_{3,}", "__", safe_name).strip("_")
+    return f"{fk}__{safe_name}"
+
+
+class PythonEdgeResolver:
+    """Resolve Python AST file data into symbol nodes and edges.
+
+    Takes file nodes (or dicts with ``rel_path`` + ``python_ast`` attribute)
+    and produces two outputs:
+    - Symbol documents for ``codebase_symbols`` collection
+    - Edge documents for ``codebase_edges`` collection
+
+    Args:
+        file_nodes: List of dicts, each with ``"rel_path"`` (str) and
+            ``"python_ast"`` (dict from ``PythonAstExtractor.extract_file``).
+    """
+
+    def __init__(self, file_nodes: list[dict[str, Any]]) -> None:
+        self._file_nodes = file_nodes
+        # Index: qualified_name → list of (file_rel_path, symbol_key)
+        self._symbol_index: dict[str, list[tuple[str, str]]] = {}
+        self._build_index()
+
+    def _build_index(self) -> None:
+        """Build a lookup from qualified symbol names to their keys."""
+        for node in self._file_nodes:
+            rel_path = node.get("rel_path", "")
+            pa = node.get("python_ast", {})
+            for sym in pa.get("symbols", []):
+                qname = sym.get("qualified_name", "")
+                if qname:
+                    sk = symbol_key(rel_path, qname)
+                    entry = (rel_path, sk)
+                    self._symbol_index.setdefault(qname, []).append(entry)
+                    # Also index by bare name for cross-file call resolution
+                    name = sym.get("name", "")
+                    if name and name != qname:
+                        file_qname = f"{rel_path}::{name}"
+                        self._symbol_index.setdefault(file_qname, []).append(entry)
+
+    def build_symbol_nodes(self) -> list[dict[str, Any]]:
+        """Build codebase_symbols documents from file-node data.
+
+        Each symbol becomes a document with:
+        - _key: file-scoped unique key
+        - name, qualified_name, kind, visibility, signature
+        - file_path: parent file rel_path
+        - line range, parent context
+        - decorators, bases
+
+        Returns:
+            List of symbol documents ready for batch insert.
+        """
+        symbols: list[dict[str, Any]] = []
+
+        for node in self._file_nodes:
+            rel_path = node.get("rel_path", "")
+            pa = node.get("python_ast", {})
+
+            for sym in pa.get("symbols", []):
+                qname = sym.get("qualified_name", "")
+                if not qname:
+                    continue
+
+                sk = symbol_key(rel_path, qname)
+
+                doc: dict[str, Any] = {
+                    "_key": sk,
+                    "name": sym.get("name", ""),
+                    "qualified_name": qname,
+                    "kind": sym.get("kind", ""),
+                    "visibility": sym.get("visibility", "public"),
+                    "signature": sym.get("signature", ""),
+                    "file_path": rel_path,
+                    "language": "python",
+                    "start_line": sym.get("start_line", 0),
+                    "end_line": sym.get("end_line", 0),
+                    "parent_symbol": sym.get("parent_symbol"),
+                    "decorators": sym.get("decorators", []),
+                    "bases": sym.get("bases", []),
+                    "analyzed_at": pa.get("analyzed_at", ""),
+                }
+                symbols.append(doc)
+
+        logger.info(
+            "Built %d symbol nodes from %d files",
+            len(symbols),
+            len(self._file_nodes),
+        )
+        return symbols
+
+    def build_edges(self) -> list[dict[str, Any]]:
+        """Build codebase_edges from file-node data.
+
+        Edge types:
+        - defines: codebase_files/{file_key} -> codebase_symbols/{symbol_key}
+        - calls: codebase_symbols/{caller} -> codebase_symbols/{callee}
+
+        Returns:
+            List of edge documents ready for batch insert.
+        """
+        edges: list[dict[str, Any]] = []
+        seen: set[tuple[str, str, str]] = set()
+
+        for node in self._file_nodes:
+            rel_path = node.get("rel_path", "")
+            pa = node.get("python_ast", {})
+            fk = file_key(rel_path)
+
+            for sym in pa.get("symbols", []):
+                qname = sym.get("qualified_name", "")
+                if not qname:
+                    continue
+                sk = symbol_key(rel_path, qname)
+
+                # 1. defines: file -> symbol
+                edge_key = (f"codebase_files/{fk}", f"codebase_symbols/{sk}", "defines")
+                if edge_key not in seen:
+                    seen.add(edge_key)
+                    edges.append({
+                        "_from": f"codebase_files/{fk}",
+                        "_to": f"codebase_symbols/{sk}",
+                        "type": "defines",
+                        "file_path": rel_path,
+                        "symbol_name": qname,
+                    })
+
+                # 2. calls: symbol -> called symbol
+                for call in sym.get("calls", []):
+                    target_sk = self._resolve_call_target(call, rel_path, qname)
+                    if target_sk:
+                        edge_key = (f"codebase_symbols/{sk}", f"codebase_symbols/{target_sk}", "calls")
+                        if edge_key not in seen:
+                            seen.add(edge_key)
+                            edges.append({
+                                "_from": f"codebase_symbols/{sk}",
+                                "_to": f"codebase_symbols/{target_sk}",
+                                "type": "calls",
+                                "caller": qname,
+                                "callee": call.get("qualified_name", call.get("name", "")),
+                            })
+
+        logger.info(
+            "Built %d edges from %d files",
+            len(edges),
+            len(self._file_nodes),
+        )
+        return edges
+
+    def _resolve_call_target(
+        self, call: dict[str, str], caller_file: str, caller_qname: str,
+    ) -> str | None:
+        """Resolve a call target to a symbol key.
+
+        Resolution strategies (parallel to ``RustEdgeResolver``):
+        1. Exact qualified_name match
+        2. ``self.method`` → look up ``ClassName.method`` in parent class
+        3. File-scoped match (file::name)
+        4. Same-file bare name match
+        5. Cross-file bare name (prefer same file)
+        """
+        target_qname = call.get("qualified_name", "")
+        target_name = call.get("name", "")
+
+        # Strategy 1: exact qualified name
+        if target_qname and target_qname in self._symbol_index:
+            sk = self._pick_best_match(self._symbol_index[target_qname], caller_file)
+            if sk:
+                return sk
+
+        # Strategy 2: self.method → ClassName.method
+        if target_qname.startswith("self.") and "." in caller_qname:
+            # caller is ClassName.method_name → parent class is ClassName
+            class_name = caller_qname.rsplit(".", 1)[0]
+            resolved = f"{class_name}.{target_name}"
+            if resolved in self._symbol_index:
+                sk = self._pick_best_match(self._symbol_index[resolved], caller_file)
+                if sk:
+                    return sk
+
+        # Strategy 3: file-scoped
+        if target_name:
+            file_scoped = f"{caller_file}::{target_name}"
+            entries = self._symbol_index.get(file_scoped, [])
+            sk = self._pick_best_match(entries, caller_file)
+            if sk:
+                return sk
+
+        # Strategy 4: bare name — prefer same file
+        if target_name and target_name in self._symbol_index:
+            sk = self._pick_best_match(self._symbol_index[target_name], caller_file)
+            if sk:
+                return sk
+
+        return None
+
+    @staticmethod
+    def _pick_best_match(
+        entries: list[tuple[str, str]], prefer_file: str,
+    ) -> str | None:
+        """Pick the best match from index entries, preferring same-file."""
+        if not entries:
+            return None
+        for file_path, sk in entries:
+            if file_path == prefer_file:
+                return sk
+        # Fallback: first match
+        return entries[0][1]

--- a/core/analyzers/python_edge_resolver.py
+++ b/core/analyzers/python_edge_resolver.py
@@ -77,11 +77,6 @@ class PythonEdgeResolver:
                     sk = symbol_key(rel_path, qname)
                     entry = (rel_path, sk)
                     self._symbol_index.setdefault(qname, []).append(entry)
-                    # Also index by bare name for cross-file call resolution
-                    name = sym.get("name", "")
-                    if name and name != qname:
-                        file_qname = f"{rel_path}::{name}"
-                        self._symbol_index.setdefault(file_qname, []).append(entry)
 
     def build_symbol_nodes(self) -> list[dict[str, Any]]:
         """Build codebase_symbols documents from file-node data.
@@ -197,12 +192,10 @@ class PythonEdgeResolver:
     ) -> str | None:
         """Resolve a call target to a symbol key.
 
-        Resolution strategies (parallel to ``RustEdgeResolver``):
+        Resolution strategies:
         1. Exact qualified_name match
         2. ``self.method`` → look up ``ClassName.method`` in parent class
-        3. File-scoped match (file::name)
-        4. Same-file bare name match
-        5. Cross-file bare name (prefer same file)
+        3. Bare name match (prefer same file)
         """
         target_qname = call.get("qualified_name", "")
         target_name = call.get("name", "")
@@ -223,15 +216,7 @@ class PythonEdgeResolver:
                 if sk:
                     return sk
 
-        # Strategy 3: file-scoped
-        if target_name:
-            file_scoped = f"{caller_file}::{target_name}"
-            entries = self._symbol_index.get(file_scoped, [])
-            sk = self._pick_best_match(entries, caller_file)
-            if sk:
-                return sk
-
-        # Strategy 4: bare name — prefer same file
+        # Strategy 3: bare name — prefer same file
         if target_name and target_name in self._symbol_index:
             sk = self._pick_best_match(self._symbol_index[target_name], caller_file)
             if sk:

--- a/core/cli/commands/codebase.py
+++ b/core/cli/commands/codebase.py
@@ -113,6 +113,152 @@ def _find_crate_roots(repo_root: str, rs_files: list[str]) -> dict[str, list[str
     return crate_map
 
 
+def _analyze_python_files(
+    file_results: list[dict[str, Any]],
+    repo_root: str,
+    client: Any,
+    db_name: str,
+    cols: CodebaseCollections,
+) -> dict[str, int]:
+    """Analyze Python files via ``ast`` and store symbols + edges.
+
+    Parallel to ``_analyze_rust_crate``:
+    1. Extract symbols from each .py file using PythonAstExtractor
+    2. Store python_ast attribute on file nodes
+    3. Materialize symbol nodes and edges via PythonEdgeResolver
+
+    Returns:
+        Dict with counts: python_symbols_created, python_edges_created.
+    """
+    import hashlib
+
+    from core.analyzers.python_ast_extractor import PythonAstExtractor
+    from core.analyzers.python_edge_resolver import PythonEdgeResolver
+    from core.database.keys import file_key as _file_key
+
+    extractor = PythonAstExtractor()
+    file_nodes: list[dict[str, Any]] = []
+
+    for file_meta in file_results:
+        rel_path = file_meta.get("rel_path", "")
+        abs_path = Path(repo_root) / rel_path
+        if not abs_path.exists():
+            continue
+
+        try:
+            ast_data = extractor.extract_file(abs_path, repo_root)
+        except Exception:
+            logger.warning("Failed to extract AST from %s", rel_path)
+            continue
+
+        if not ast_data.get("symbols") and not ast_data.get("imports"):
+            continue
+
+        # Update file_meta with structured imports so ImportResolver
+        # gets the right format (module/name keys) without re-extraction
+        if ast_data.get("imports"):
+            file_meta["symbols"] = {"imports": ast_data["imports"]}
+
+        # Update the file node with python_ast attribute
+        fk = _file_key(rel_path)
+        client.request(
+            "PATCH",
+            f"/_db/{db_name}/_api/document/{cols.files}/{fk}",
+            json={
+                "python_ast": ast_data,
+                "language": "python",
+            },
+        )
+
+        file_nodes.append({
+            "rel_path": rel_path,
+            "python_ast": ast_data,
+        })
+
+    if not file_nodes:
+        return {"python_symbols_created": 0, "python_edges_created": 0}
+
+    # Clear stale Python symbols and edges before inserting new ones
+    python_edge_types = ["defines", "calls"]
+    all_paths = [n["rel_path"] for n in file_nodes]
+
+    col_resp = client.request("GET", f"/_db/{db_name}/_api/collection")
+    existing_cols = {c["name"] for c in col_resp.get("result", [])}
+    has_symbols = cols.symbols in existing_cols
+    has_edges = cols.edges in existing_cols
+
+    if has_symbols:
+        _BATCH = 30
+        for i in range(0, len(all_paths), _BATCH):
+            batch = all_paths[i : i + _BATCH]
+            file_ids = [f"{cols.files}/{_file_key(p)}" for p in batch]
+
+            if has_edges:
+                client.query(
+                    """
+                    LET sym_ids = (
+                        FOR s IN @@symbols
+                            FILTER s.file_path IN @paths AND s.language == "python"
+                            RETURN s._id
+                    )
+                    LET all_ids = APPEND(sym_ids, @file_ids)
+                    FOR e IN @@edges
+                        FILTER e.type IN @types
+                            AND (e._from IN all_ids OR e._to IN all_ids)
+                        REMOVE e IN @@edges
+                    """,
+                    bind_vars={
+                        "@symbols": cols.symbols,
+                        "@edges": cols.edges,
+                        "paths": batch,
+                        "file_ids": file_ids,
+                        "types": python_edge_types,
+                    },
+                )
+
+            client.query(
+                'FOR s IN @@symbols FILTER s.file_path IN @paths AND s.language == "python" REMOVE s IN @@symbols',
+                bind_vars={"@symbols": cols.symbols, "paths": batch},
+            )
+
+    # Materialize symbol nodes and edges
+    resolver = PythonEdgeResolver(file_nodes)
+    symbol_docs = resolver.build_symbol_nodes()
+    edge_docs = resolver.build_edges()
+
+    symbols_created = 0
+    for doc in symbol_docs:
+        client.request(
+            "POST",
+            f"/_db/{db_name}/_api/document/{cols.symbols}",
+            json=doc,
+            params={"overwriteMode": "replace"},
+        )
+        symbols_created += 1
+
+    edges_created = 0
+    for edge in edge_docs:
+        identity = f"{edge['_from']}|{edge['_to']}|{edge['type']}"
+        edge["_key"] = hashlib.sha256(identity.encode()).hexdigest()
+        client.request(
+            "POST",
+            f"/_db/{db_name}/_api/document/{cols.edges}",
+            json=edge,
+            params={"overwriteMode": "replace"},
+        )
+        edges_created += 1
+
+    print(
+        f"  python-ast: {symbols_created} symbols, {edges_created} edges from {len(file_nodes)} files",
+        file=sys.stderr,
+    )
+
+    return {
+        "python_symbols_created": symbols_created,
+        "python_edges_created": edges_created,
+    }
+
+
 def _analyze_rust_crate(
     crate_root: str,
     rs_files: list[str],
@@ -440,7 +586,18 @@ def codebase_ingest(
                 file=sys.stderr,
             )
 
-        # Resolve imports and create edges
+        # ── Python AST analysis ───────────────────────────────────
+        # Run BEFORE import resolution: _analyze_python_files updates
+        # file_results with structured import data (module/name keys)
+        # that ImportResolver needs.
+        python_stats: dict[str, int] = {"python_symbols_created": 0, "python_edges_created": 0}
+
+        if file_results:
+            python_stats = _analyze_python_files(
+                file_results, repo_root, client, db_name, cols,
+            )
+
+        # Resolve imports and create edges (using AST-structured import data)
         from core.database.import_resolver import ImportResolver
 
         known_rel_paths = {fr["rel_path"] for fr in file_results}
@@ -565,6 +722,8 @@ def codebase_ingest(
                 "files_total": len(py_files) + len(rs_files),
                 "chunks_created": chunks_created,
                 "edges_created": edges_created,
+                "python_files": len(py_files),
+                **python_stats,
                 "rust_files": len(rs_files),
                 **rust_stats,
             },

--- a/core/cli/commands/codebase.py
+++ b/core/cli/commands/codebase.py
@@ -138,21 +138,20 @@ def _analyze_python_files(
 
     extractor = PythonAstExtractor()
     file_nodes: list[dict[str, Any]] = []
+    attempted_paths: list[str] = []
 
     for file_meta in file_results:
         rel_path = file_meta.get("rel_path", "")
         abs_path = Path(repo_root) / rel_path
         if not abs_path.exists():
             continue
+        attempted_paths.append(rel_path)
 
         try:
             ast_data = extractor.extract_file(abs_path, repo_root)
         except Exception:
             logger.warning("Failed to extract AST from %s", rel_path)
-            continue
-
-        if not ast_data.get("symbols") and not ast_data.get("imports"):
-            continue
+            ast_data = {"symbols": [], "imports": [], "analyzed_at": ""}
 
         # Update file_meta with structured imports so ImportResolver
         # gets the right format (module/name keys) without re-extraction
@@ -170,17 +169,18 @@ def _analyze_python_files(
             },
         )
 
-        file_nodes.append({
-            "rel_path": rel_path,
-            "python_ast": ast_data,
-        })
+        if ast_data.get("symbols") or ast_data.get("imports"):
+            file_nodes.append({
+                "rel_path": rel_path,
+                "python_ast": ast_data,
+            })
 
-    if not file_nodes:
+    if not attempted_paths:
         return {"python_symbols_created": 0, "python_edges_created": 0}
 
     # Clear stale Python symbols and edges before inserting new ones
     python_edge_types = ["defines", "calls"]
-    all_paths = [n["rel_path"] for n in file_nodes]
+    all_paths = attempted_paths
 
     col_resp = client.request("GET", f"/_db/{db_name}/_api/collection")
     existing_cols = {c["name"] for c in col_resp.get("result", [])}

--- a/tests/core/analyzers/test_python_ast_extractor.py
+++ b/tests/core/analyzers/test_python_ast_extractor.py
@@ -1,0 +1,299 @@
+"""Tests for the Python AST extractor.
+
+Validates that symbols and imports are correctly extracted from Python
+source code using the standard ``ast`` module.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from core.analyzers.python_ast_extractor import PythonAstExtractor
+
+
+@pytest.fixture
+def extractor() -> PythonAstExtractor:
+    return PythonAstExtractor()
+
+
+# ── Symbol extraction ─────────────────────────────────────────────
+
+
+class TestFunctions:
+    def test_top_level_function(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            def greet(name: str) -> str:
+                return f"hello {name}"
+        """))
+        data = extractor.extract_file(str(src))
+        syms = data["symbols"]
+        assert len(syms) == 1
+        s = syms[0]
+        assert s["name"] == "greet"
+        assert s["qualified_name"] == "greet"
+        assert s["kind"] == "function"
+        assert s["visibility"] == "public"
+        assert "name: str" in s["signature"]
+        assert "-> str" in s["signature"]
+        assert s["start_line"] == 1
+
+    def test_async_function(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            async def fetch(url: str) -> bytes:
+                pass
+        """))
+        data = extractor.extract_file(str(src))
+        s = data["symbols"][0]
+        assert s["kind"] == "function"
+        assert s["signature"].startswith("async def")
+
+    def test_decorated_function(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            import functools
+
+            @functools.cache
+            def expensive(n: int) -> int:
+                return n * n
+        """))
+        data = extractor.extract_file(str(src))
+        fn = [s for s in data["symbols"] if s["kind"] == "function"][0]
+        assert "functools.cache" in fn["decorators"]
+
+
+class TestClasses:
+    def test_class_with_methods(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            class Dog:
+                breed: str
+
+                def __init__(self, name: str):
+                    self.name = name
+
+                def bark(self) -> str:
+                    return "woof"
+
+                @staticmethod
+                def species() -> str:
+                    return "canis"
+
+                @classmethod
+                def from_shelter(cls, id: int) -> "Dog":
+                    pass
+
+                @property
+                def tag(self) -> str:
+                    return self.name
+        """))
+        data = extractor.extract_file(str(src))
+        names = {s["qualified_name"]: s for s in data["symbols"]}
+
+        assert "Dog" in names
+        assert names["Dog"]["kind"] == "class"
+
+        assert "Dog.__init__" in names
+        assert names["Dog.__init__"]["kind"] == "method"
+        assert names["Dog.__init__"]["visibility"] == "dunder"
+
+        assert "Dog.bark" in names
+        assert names["Dog.bark"]["kind"] == "method"
+
+        assert "Dog.species" in names
+        assert names["Dog.species"]["kind"] == "staticmethod"
+
+        assert "Dog.from_shelter" in names
+        assert names["Dog.from_shelter"]["kind"] == "classmethod"
+
+        assert "Dog.tag" in names
+        assert names["Dog.tag"]["kind"] == "property"
+
+    def test_class_bases(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            class MyError(ValueError, RuntimeError):
+                pass
+        """))
+        data = extractor.extract_file(str(src))
+        cls = data["symbols"][0]
+        assert cls["bases"] == ["ValueError", "RuntimeError"]
+
+    def test_class_attributes(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            class Config:
+                MAX_RETRIES: int = 3
+                timeout: float = 30.0
+        """))
+        data = extractor.extract_file(str(src))
+        # UPPER_CASE class vars are "constant", lowercase are "attribute"
+        non_class = [s for s in data["symbols"] if s["kind"] != "class"]
+        names = {s["name"]: s["kind"] for s in non_class}
+        assert names["MAX_RETRIES"] == "constant"
+        assert names["timeout"] == "attribute"
+
+
+class TestVisibility:
+    def test_private_method(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            class Foo:
+                def __secret(self):
+                    pass
+        """))
+        data = extractor.extract_file(str(src))
+        method = [s for s in data["symbols"] if s["name"] == "__secret"][0]
+        assert method["visibility"] == "private"
+
+    def test_protected_method(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            class Foo:
+                def _internal(self):
+                    pass
+        """))
+        data = extractor.extract_file(str(src))
+        method = [s for s in data["symbols"] if s["name"] == "_internal"][0]
+        assert method["visibility"] == "protected"
+
+
+class TestConstants:
+    def test_module_level_constants(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            MAX_SIZE = 1024
+            DEFAULT_NAME = "unknown"
+            _internal_var = True
+        """))
+        data = extractor.extract_file(str(src))
+        names = {s["name"] for s in data["symbols"]}
+        assert "MAX_SIZE" in names
+        assert "DEFAULT_NAME" in names
+        # lowercase module-level vars should NOT be captured
+        assert "_internal_var" not in names
+
+
+class TestLocalVariables:
+    def test_local_vars_not_captured(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            def process():
+                result = []
+                count = 0
+                MAX_LOCAL = 100
+                for item in result:
+                    count += 1
+                return count
+        """))
+        data = extractor.extract_file(str(src))
+        # Only the function itself should be a symbol, not its local vars
+        assert len(data["symbols"]) == 1
+        assert data["symbols"][0]["name"] == "process"
+
+
+class TestCallExtraction:
+    def test_simple_calls(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            def outer():
+                inner()
+                print("hello")
+        """))
+        data = extractor.extract_file(str(src))
+        fn = data["symbols"][0]
+        call_names = {c["name"] for c in fn.get("calls", [])}
+        assert "inner" in call_names
+        assert "print" in call_names
+
+    def test_method_calls(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            class Foo:
+                def bar(self):
+                    self.baz()
+                    other.method()
+        """))
+        data = extractor.extract_file(str(src))
+        method = [s for s in data["symbols"] if s["name"] == "bar"][0]
+        call_names = {c["name"] for c in method.get("calls", [])}
+        assert "baz" in call_names
+        assert "method" in call_names
+
+
+# ── Import extraction ─────────────────────────────────────────────
+
+
+class TestImports:
+    def test_plain_import(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text("import os\nimport sys\n")
+        data = extractor.extract_file(str(src))
+        imports = data["imports"]
+        modules = {i["module"] for i in imports}
+        assert "os" in modules
+        assert "sys" in modules
+        assert all(i["type"] == "import" for i in imports)
+
+    def test_from_import(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text("from pathlib import Path, PurePath\n")
+        data = extractor.extract_file(str(src))
+        imports = data["imports"]
+        assert len(imports) == 2
+        assert all(i["module"] == "pathlib" for i in imports)
+        names = {i["name"] for i in imports}
+        assert names == {"Path", "PurePath"}
+        assert all(i["type"] == "from_import" for i in imports)
+
+    def test_relative_import(self, extractor, tmp_path):
+        src = tmp_path / "mod.py"
+        src.write_text("from . import sibling\nfrom ..parent import Thing\n")
+        data = extractor.extract_file(str(src))
+        imports = data["imports"]
+        assert len(imports) == 2
+        # Relative imports should have dots prepended to module
+        rel1 = [i for i in imports if i["name"] == "sibling"][0]
+        assert rel1["module"] == "."
+        assert rel1["level"] == 1
+        rel2 = [i for i in imports if i["name"] == "Thing"][0]
+        assert rel2["module"] == "..parent"
+        assert rel2["level"] == 2
+
+    def test_import_format_matches_resolver(self, extractor, tmp_path):
+        """Imports must have 'module' and 'name' keys for ImportResolver."""
+        src = tmp_path / "mod.py"
+        src.write_text("from core.database.keys import file_key\n")
+        data = extractor.extract_file(str(src))
+        imp = data["imports"][0]
+        assert "module" in imp
+        assert "name" in imp
+        assert imp["module"] == "core.database.keys"
+        assert imp["name"] == "file_key"
+
+
+# ── Edge cases ────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_syntax_error_returns_empty(self, extractor, tmp_path):
+        src = tmp_path / "bad.py"
+        src.write_text("def broken(\n")
+        data = extractor.extract_file(str(src))
+        assert data["symbols"] == []
+        assert data["imports"] == []
+
+    def test_missing_file_returns_empty(self, extractor):
+        data = extractor.extract_file("/nonexistent/file.py")
+        assert data["symbols"] == []
+
+    def test_empty_file(self, extractor, tmp_path):
+        src = tmp_path / "empty.py"
+        src.write_text("")
+        data = extractor.extract_file(str(src))
+        assert data["symbols"] == []
+        assert data["imports"] == []
+        assert "analyzed_at" in data

--- a/tests/core/analyzers/test_python_ast_extractor.py
+++ b/tests/core/analyzers/test_python_ast_extractor.py
@@ -209,6 +209,22 @@ class TestCallExtraction:
         assert "inner" in call_names
         assert "print" in call_names
 
+    def test_nested_calls_not_leaked(self, extractor, tmp_path):
+        """Calls inside nested functions must not leak to the outer scope."""
+        src = tmp_path / "mod.py"
+        src.write_text(textwrap.dedent("""\
+            def outer():
+                def inner():
+                    helper()
+                inner()
+        """))
+        data = extractor.extract_file(str(src))
+        outer_fn = [s for s in data["symbols"] if s["name"] == "outer"][0]
+        outer_calls = {c["name"] for c in outer_fn.get("calls", [])}
+        # outer should call inner, but NOT helper (belongs to inner)
+        assert "inner" in outer_calls
+        assert "helper" not in outer_calls
+
     def test_method_calls(self, extractor, tmp_path):
         src = tmp_path / "mod.py"
         src.write_text(textwrap.dedent("""\

--- a/tests/core/analyzers/test_python_edge_resolver.py
+++ b/tests/core/analyzers/test_python_edge_resolver.py
@@ -1,0 +1,212 @@
+"""Tests for the Python edge resolver.
+
+Validates that symbol nodes and edges are correctly materialized
+from python_ast file-node attributes.  Structurally mirrors
+test_rust_edge_resolver.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.analyzers.python_edge_resolver import PythonEdgeResolver, symbol_key
+from core.database.keys import file_key
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _make_file_node(
+    rel_path: str,
+    symbols: list[dict],
+    imports: list[dict] | None = None,
+) -> dict:
+    """Build a file node with python_ast attribute."""
+    return {
+        "rel_path": rel_path,
+        "python_ast": {
+            "symbols": symbols,
+            "imports": imports or [],
+            "analyzed_at": "2026-04-06T00:00:00+00:00",
+        },
+    }
+
+
+# ── symbol_key ────────────────────────────────────────────────────
+
+
+class TestSymbolKey:
+    def test_basic(self):
+        assert symbol_key("core/db.py", "Pool") == "core_db_py__Pool"
+
+    def test_method(self):
+        sk = symbol_key("core/db.py", "Pool.acquire")
+        assert sk == "core_db_py__Pool_acquire"
+
+    def test_dunder(self):
+        sk = symbol_key("core/db.py", "Pool.__init__")
+        assert sk == "core_db_py__Pool__init"
+
+    def test_nested(self):
+        sk = symbol_key("mod.py", "Outer.Inner.method")
+        assert sk == "mod_py__Outer_Inner_method"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pool_file() -> dict:
+    """File node for db.py with a class and two methods."""
+    return _make_file_node(
+        "core/db.py",
+        symbols=[
+            {
+                "name": "Pool",
+                "qualified_name": "Pool",
+                "kind": "class",
+                "visibility": "public",
+                "signature": "class Pool",
+                "start_line": 10,
+                "end_line": 50,
+                "parent_symbol": None,
+                "decorators": [],
+                "bases": [],
+            },
+            {
+                "name": "__init__",
+                "qualified_name": "Pool.__init__",
+                "kind": "method",
+                "visibility": "dunder",
+                "signature": "def __init__(self, size: int)",
+                "start_line": 12,
+                "end_line": 20,
+                "parent_symbol": "Pool",
+                "decorators": [],
+                "calls": [{"name": "connect", "qualified_name": "self.connect"}],
+            },
+            {
+                "name": "connect",
+                "qualified_name": "Pool.connect",
+                "kind": "method",
+                "visibility": "public",
+                "signature": "def connect(self) -> Connection",
+                "start_line": 22,
+                "end_line": 30,
+                "parent_symbol": "Pool",
+                "decorators": [],
+                "calls": [],
+            },
+        ],
+    )
+
+
+@pytest.fixture
+def utils_file() -> dict:
+    """File node for utils.py with a standalone function."""
+    return _make_file_node(
+        "core/utils.py",
+        symbols=[
+            {
+                "name": "validate",
+                "qualified_name": "validate",
+                "kind": "function",
+                "visibility": "public",
+                "signature": "def validate(data: dict) -> bool",
+                "start_line": 1,
+                "end_line": 10,
+                "parent_symbol": None,
+                "decorators": [],
+                "calls": [],
+            },
+        ],
+    )
+
+
+# ── Symbol nodes ──────────────────────────────────────────────────
+
+
+class TestBuildSymbolNodes:
+    def test_creates_symbol_docs(self, pool_file):
+        resolver = PythonEdgeResolver([pool_file])
+        docs = resolver.build_symbol_nodes()
+        assert len(docs) == 3
+        keys = {d["_key"] for d in docs}
+        assert symbol_key("core/db.py", "Pool") in keys
+        assert symbol_key("core/db.py", "Pool.__init__") in keys
+        assert symbol_key("core/db.py", "Pool.connect") in keys
+
+    def test_symbol_doc_fields(self, pool_file):
+        resolver = PythonEdgeResolver([pool_file])
+        docs = resolver.build_symbol_nodes()
+        pool = [d for d in docs if d["name"] == "Pool"][0]
+        assert pool["kind"] == "class"
+        assert pool["visibility"] == "public"
+        assert pool["language"] == "python"
+        assert pool["file_path"] == "core/db.py"
+        assert pool["start_line"] == 10
+        assert pool["end_line"] == 50
+
+    def test_multi_file(self, pool_file, utils_file):
+        resolver = PythonEdgeResolver([pool_file, utils_file])
+        docs = resolver.build_symbol_nodes()
+        assert len(docs) == 4  # 3 from pool + 1 from utils
+
+
+# ── Edges ─────────────────────────────────────────────────────────
+
+
+class TestBuildEdges:
+    def test_defines_edges(self, pool_file):
+        resolver = PythonEdgeResolver([pool_file])
+        edges = resolver.build_edges()
+        defines = [e for e in edges if e["type"] == "defines"]
+        # One defines edge per symbol
+        assert len(defines) == 3
+        fk = file_key("core/db.py")
+        for e in defines:
+            assert e["_from"] == f"codebase_files/{fk}"
+            assert e["_to"].startswith("codebase_symbols/")
+
+    def test_self_call_resolved(self, pool_file):
+        """self.connect() in __init__ should resolve to Pool.connect."""
+        resolver = PythonEdgeResolver([pool_file])
+        edges = resolver.build_edges()
+        calls = [e for e in edges if e["type"] == "calls"]
+        assert len(calls) == 1
+        e = calls[0]
+        assert e["caller"] == "Pool.__init__"
+        assert e["callee"] == "self.connect"
+        # Target should be Pool.connect's symbol key
+        expected_to = f"codebase_symbols/{symbol_key('core/db.py', 'Pool.connect')}"
+        assert e["_to"] == expected_to
+
+    def test_cross_file_call(self, pool_file, utils_file):
+        """A call to 'validate' should resolve cross-file."""
+        pool_file["python_ast"]["symbols"][2]["calls"] = [
+            {"name": "validate", "qualified_name": "validate"},
+        ]
+        resolver = PythonEdgeResolver([pool_file, utils_file])
+        edges = resolver.build_edges()
+        calls = [e for e in edges if e["type"] == "calls"]
+        cross = [c for c in calls if c["callee"] == "validate"]
+        assert len(cross) == 1
+        expected_to = f"codebase_symbols/{symbol_key('core/utils.py', 'validate')}"
+        assert cross[0]["_to"] == expected_to
+
+    def test_dedup_edges(self, pool_file):
+        """Duplicate edges should be deduplicated."""
+        # Add a second call to the same target
+        pool_file["python_ast"]["symbols"][1]["calls"] = [
+            {"name": "connect", "qualified_name": "self.connect"},
+            {"name": "connect", "qualified_name": "self.connect"},
+        ]
+        resolver = PythonEdgeResolver([pool_file])
+        edges = resolver.build_edges()
+        calls = [e for e in edges if e["type"] == "calls"]
+        assert len(calls) == 1
+
+    def test_empty_file_nodes(self):
+        resolver = PythonEdgeResolver([])
+        assert resolver.build_symbol_nodes() == []
+        assert resolver.build_edges() == []


### PR DESCRIPTION
## Summary
- Add symbol-level analysis for Python files during codebase ingestion, parallel to the existing Rust analyzer pipeline
- Python files now get `defines` and `calls` edges in the knowledge graph (previously only had file-level `imports` edges from `ImportResolver`)
- `PythonAstExtractor` uses the standard `ast` module — zero external dependencies

## Changes
| File | What |
|------|------|
| `core/analyzers/python_ast_extractor.py` | Extract functions, classes, methods, constants, imports, and call sites via `ast` module |
| `core/analyzers/python_edge_resolver.py` | Materialize `codebase_symbols` nodes + `codebase_edges` (defines, calls) from `python_ast` attribute |
| `core/cli/commands/codebase.py` | `_analyze_python_files()` orchestration: extract → stale cleanup → symbol/edge insertion |
| `tests/core/analyzers/test_python_ast_extractor.py` | 19 tests: functions, classes, visibility, constants, calls, imports, edge cases |
| `tests/core/analyzers/test_python_edge_resolver.py` | 12 tests: symbol keys, symbol nodes, defines/calls edges, cross-file resolution, dedup |

## Test plan
- [x] 31 tests all passing
- [x] Compile check clean
- [x] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python source analysis to extract symbols, imports, and call/definition relationships.
  * Integrated Python symbol and edge materialization into codebase ingestion, with stale-data cleanup and ingestion stats reported.
* **Tests**
  * Added comprehensive tests covering Python AST extraction and symbol/edge resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->